### PR TITLE
feat: add i32/u32 support to ScVal normalizer with fallback handling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "react-dom": "^19.2.0",
         "sass": "^1.97.3",
         "tailwindcss": "^4.0.6",
+        "zustand": "^5.0.11",
       },
       "devDependencies": {
         "@tanstack/devtools-vite": "^0.3.11",
@@ -955,6 +956,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zustand": ["zustand@5.0.11", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 

--- a/src/test/decoder/primitive.numeric.test.ts
+++ b/src/test/decoder/primitive.numeric.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+import { ScValType, normalizeScVal } from '../../workers/decoder/normalizeScVal'
+import type { ScVal, UnsupportedFallback } from '../../workers/decoder/normalizeScVal'
+
+describe('normalizeScVal - Numeric Primitives', () => {
+  describe('i32 support', () => {
+    it('should normalize valid i32 values correctly', () => {
+      const testCases = [
+        { value: 0, expected: 0 },
+        { value: 1, expected: 1 },
+        { value: -1, expected: -1 },
+        { value: 2147483647, expected: 2147483647 }, // Max i32
+        { value: -2147483648, expected: -2147483648 }, // Min i32
+        { value: 42, expected: 42 },
+        { value: -42, expected: -42 },
+      ]
+
+      testCases.forEach(({ value, expected }) => {
+        const scVal: ScVal = {
+          switch: ScValType.SCV_I32,
+          value,
+        }
+        const result = normalizeScVal(scVal)
+        expect(result).toBe(expected)
+      })
+    })
+
+    it('should return fallback for invalid i32 values', () => {
+      const invalidCases = [
+        { value: 2147483648, expected: 2147483648 }, // Max i32 + 1
+        { value: -2147483649, expected: -2147483649 }, // Min i32 - 1
+        { value: 3.14, expected: 3.14 }, // Float
+        { value: 'not a number', expected: 'not a number' }, // String
+        { value: null, expected: null }, // Null
+        { value: undefined, expected: null }, // Undefined -> null
+      ]
+
+      invalidCases.forEach(({ value, expected }) => {
+        const scVal: ScVal = {
+          switch: ScValType.SCV_I32,
+          value,
+        }
+        const result = normalizeScVal(scVal) as UnsupportedFallback
+        expect(result.__unsupported).toBe(true)
+        expect(result.variant).toBe(ScValType.SCV_I32)
+        expect(result.rawData).toBe(expected)
+      })
+    })
+  })
+
+  describe('u32 support', () => {
+    it('should normalize valid u32 values correctly', () => {
+      const testCases = [
+        { value: 0, expected: 0 },
+        { value: 1, expected: 1 },
+        { value: 4294967295, expected: 4294967295 }, // Max u32
+        { value: 42, expected: 42 },
+        { value: 1000000, expected: 1000000 },
+      ]
+
+      testCases.forEach(({ value, expected }) => {
+        const scVal: ScVal = {
+          switch: ScValType.SCV_U32,
+          value,
+        }
+        const result = normalizeScVal(scVal)
+        expect(result).toBe(expected)
+      })
+    })
+
+    it('should return fallback for invalid u32 values', () => {
+      const invalidCases = [
+        { value: -1, expected: -1 }, // Negative
+        { value: 4294967296, expected: 4294967296 }, // Max u32 + 1
+        { value: 3.14, expected: 3.14 }, // Float
+        { value: 'not a number', expected: 'not a number' }, // String
+        { value: null, expected: null }, // Null
+        { value: undefined, expected: null }, // Undefined -> null
+      ]
+
+      invalidCases.forEach(({ value, expected }) => {
+        const scVal: ScVal = {
+          switch: ScValType.SCV_U32,
+          value,
+        }
+        const result = normalizeScVal(scVal) as UnsupportedFallback
+        expect(result.__unsupported).toBe(true)
+        expect(result.variant).toBe(ScValType.SCV_U32)
+        expect(result.rawData).toBe(expected)
+      })
+    })
+  })
+
+  describe('unsupported fallback behavior', () => {
+    it('should return stable fallback for unsupported variants', () => {
+      const unsupportedVariants = [
+        ScValType.SCV_U64,
+        ScValType.SCV_I64,
+        ScValType.SCV_U128,
+        ScValType.SCV_I128,
+        ScValType.SCV_BYTES,
+        ScValType.SCV_VEC,
+        ScValType.SCV_MAP,
+      ]
+
+      unsupportedVariants.forEach((variant) => {
+        const scVal: ScVal = {
+          switch: variant,
+          value: 'test-data',
+        }
+        const result = normalizeScVal(scVal) as UnsupportedFallback
+        expect(result.__unsupported).toBe(true)
+        expect(result.variant).toBe(variant)
+        expect(result.rawData).toBe('test-data')
+      })
+    })
+
+    it('should handle missing or null raw data in fallback', () => {
+      const scVal: ScVal = {
+        switch: ScValType.SCV_U64,
+        // No value property
+      }
+      const result = normalizeScVal(scVal) as UnsupportedFallback
+      expect(result.__unsupported).toBe(true)
+      expect(result.variant).toBe(ScValType.SCV_U64)
+      expect(result.rawData).toBe(null)
+    })
+
+    it('should return deterministic fallback objects', () => {
+      const scVal: ScVal = {
+        switch: ScValType.SCV_BYTES,
+        value: [1, 2, 3],
+      }
+      
+      const result1 = normalizeScVal(scVal) as UnsupportedFallback
+      const result2 = normalizeScVal(scVal) as UnsupportedFallback
+      
+      expect(result1).toEqual(result2)
+      expect(JSON.stringify(result1)).toBe(JSON.stringify(result2))
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle invalid ScVal input', () => {
+      const invalidInputs = [
+        { input: null, expectedVariant: 'Invalid' },
+        { input: undefined, expectedVariant: 'Invalid' },
+        { input: {}, expectedVariant: 'Invalid' },
+        { input: { switch: null }, expectedVariant: 'Invalid' },
+        { input: { switch: 'InvalidType' }, expectedVariant: 'InvalidType' },
+      ]
+
+      invalidInputs.forEach(({ input, expectedVariant }) => {
+        const result = normalizeScVal(input as any) as UnsupportedFallback
+        expect(result.__unsupported).toBe(true)
+        expect(result.variant).toBe(expectedVariant)
+      })
+    })
+
+    it('should handle supported types with correct values', () => {
+      const supportedCases = [
+        { switch: ScValType.SCV_BOOL, value: true, expected: true },
+        { switch: ScValType.SCV_BOOL, value: false, expected: false },
+        { switch: ScValType.SCV_VOID, value: undefined, expected: null },
+        { switch: ScValType.SCV_STRING, value: 'hello', expected: 'hello' },
+        { switch: ScValType.SCV_SYMBOL, value: 'symbol', expected: 'symbol' },
+      ]
+
+      supportedCases.forEach(({ switch: switchType, value, expected }) => {
+        const scVal: ScVal = { switch: switchType, value }
+        const result = normalizeScVal(scVal)
+        expect(result).toBe(expected)
+      })
+    })
+  })
+})

--- a/src/workers/decoder/normalizeScVal.ts
+++ b/src/workers/decoder/normalizeScVal.ts
@@ -1,0 +1,105 @@
+/**
+ * ScVal normalization utilities for Soroban State Lens
+ * Handles conversion of Stellar Contract Values to normalized JSON-like structures
+ */
+
+// ScVal variant types based on Stellar XDR definitions
+export enum ScValType {
+  SCV_BOOL = 'ScvBool',
+  SCV_VOID = 'ScvVoid', 
+  SCV_U32 = 'ScvU32',
+  SCV_I32 = 'ScvI32',
+  SCV_U64 = 'ScvU64',
+  SCV_I64 = 'ScvI64',
+  SCV_TIMEPOINT = 'ScvTimepoint',
+  SCV_DURATION = 'ScvDuration',
+  SCV_U128 = 'ScvU128',
+  SCV_I128 = 'ScvI128',
+  SCV_U256 = 'ScvU256',
+  SCV_I256 = 'ScvI256',
+  SCV_BYTES = 'ScvBytes',
+  SCV_STRING = 'ScvString',
+  SCV_SYMBOL = 'ScvSymbol',
+  SCV_VEC = 'ScvVec',
+  SCV_MAP = 'ScvMap',
+  SCV_ADDRESS = 'ScvAddress',
+  SCV_CONTRACT_INSTANCE = 'ScvContractInstance',
+  SCV_LEDGER_KEY_CONTRACT_INSTANCE = 'ScvLedgerKeyContractInstance',
+  SCV_LEDGER_KEY_NONCE = 'ScvLedgerKeyNonce',
+}
+
+// Basic ScVal structure
+export interface ScVal {
+  switch: ScValType
+  value?: unknown
+}
+
+// Fallback object for unsupported variants
+export interface UnsupportedFallback {
+  __unsupported: true
+  variant: string
+  rawData: unknown
+}
+
+// Normalized output types
+export type NormalizedValue = 
+  | boolean
+  | number
+  | string
+  | null
+  | UnsupportedFallback
+  | Array<NormalizedValue>
+  | { [key: string]: NormalizedValue }
+
+/**
+ * Creates a deterministic fallback object for unsupported ScVal variants
+ */
+function createUnsupportedFallback(variant: string, rawData: unknown): UnsupportedFallback {
+  return {
+    __unsupported: true,
+    variant,
+    rawData: rawData === undefined ? null : rawData,
+  }
+}
+
+/**
+ * Normalizes an ScVal to a JSON-serializable format
+ * Supports i32, u32, and provides fallback for unsupported variants
+ */
+export function normalizeScVal(scVal: ScVal | null | undefined): NormalizedValue {
+  if (!scVal || typeof scVal.switch !== 'string') {
+    return createUnsupportedFallback('Invalid', scVal)
+  }
+
+  switch (scVal.switch) {
+    case ScValType.SCV_BOOL:
+      return typeof scVal.value === 'boolean' ? scVal.value : false
+
+    case ScValType.SCV_VOID:
+      return null
+
+    case ScValType.SCV_U32:
+      // Handle u32 - ensure it's a valid 32-bit unsigned integer
+      if (typeof scVal.value === 'number' && Number.isInteger(scVal.value) && scVal.value >= 0 && scVal.value <= 0xFFFFFFFF) {
+        return scVal.value
+      }
+      return createUnsupportedFallback(ScValType.SCV_U32, scVal.value)
+
+    case ScValType.SCV_I32:
+      // Handle i32 - ensure it's a valid 32-bit signed integer
+      if (typeof scVal.value === 'number' && Number.isInteger(scVal.value) && scVal.value >= -0x80000000 && scVal.value <= 0x7FFFFFFF) {
+        return scVal.value
+      }
+      return createUnsupportedFallback(ScValType.SCV_I32, scVal.value)
+
+    case ScValType.SCV_STRING:
+      return typeof scVal.value === 'string' ? scVal.value : ''
+
+    case ScValType.SCV_SYMBOL:
+      return typeof scVal.value === 'string' ? scVal.value : ''
+
+    // All other variants return unsupported fallback
+    default:
+      return createUnsupportedFallback(scVal.switch, scVal.value)
+  }
+}


### PR DESCRIPTION
Close #22 
Added i32/u32 support to ScVal normalizer with fallback handling for unsupported variants. Created comprehensive tests. All verification steps pass.