### PR TITLE
feat:implement network persistence

### DIFF
--- a/src/store/lensStore.ts
+++ b/src/store/lensStore.ts
@@ -1,7 +1,15 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 import { DEFAULT_NETWORKS } from './types'
+import {
+  DEFAULT_NETWORK_CONFIG,
+  NETWORK_CONFIG_STORAGE_KEY,
+  createSafeStorage,
+  mergeNetworkConfig,
+} from './persistence'
 
+import type { PersistedState } from './persistence'
 import type {
   ExpandedNodesSlice,
   LedgerDataSlice,
@@ -12,10 +20,8 @@ import type {
   NetworkConfigSlice,
 } from './types'
 
-/**
- * Default initial state
- */
-const DEFAULT_NETWORK_CONFIG: NetworkConfig = DEFAULT_NETWORKS.futurenet
+// Re-export for backwards compatibility
+export { DEFAULT_NETWORKS }
 
 /**
  * Network config slice creator
@@ -115,19 +121,34 @@ const createExpandedNodesSlice = (
 })
 
 /**
- * Combined Lens Store
+ * Combined Lens Store with persistence for networkConfig only
  *
  * Centralized state management for Soroban State Lens.
  * Includes slices for:
- * - networkConfig: Current network configuration
- * - ledgerData: Cached ledger entries
- * - expandedNodes: Tree view expansion state
+ * - networkConfig: Current network configuration (PERSISTED)
+ * - ledgerData: Cached ledger entries (NOT persisted)
+ * - expandedNodes: Tree view expansion state (NOT persisted)
  */
-export const useLensStore = create<LensStore>((set) => ({
-  ...createNetworkConfigSlice(set),
-  ...createLedgerDataSlice(set),
-  ...createExpandedNodesSlice(set),
-}))
+export const useLensStore = create<LensStore>()(
+  persist<LensStore, [], [], PersistedState>(
+    (set) => ({
+      ...createNetworkConfigSlice(set),
+      ...createLedgerDataSlice(set),
+      ...createExpandedNodesSlice(set),
+    }),
+    {
+      name: NETWORK_CONFIG_STORAGE_KEY,
+      storage: createSafeStorage<PersistedState>(),
+      // Only persist networkConfig slice
+      partialize: (state): PersistedState => ({ networkConfig: state.networkConfig }),
+      // Validate and merge persisted data safely
+      merge: (persistedState, currentState) => ({
+        ...currentState,
+        ...mergeNetworkConfig(persistedState, currentState),
+      }),
+    }
+  )
+)
 
 /**
  * Selector hooks for common use cases

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -1,0 +1,125 @@
+import { createJSONStorage } from 'zustand/middleware'
+
+import { DEFAULT_NETWORKS } from './types'
+
+import type { NetworkConfig } from './types'
+import type { PersistStorage } from 'zustand/middleware'
+
+/**
+ * Storage key for network config persistence
+ */
+export const NETWORK_CONFIG_STORAGE_KEY = 'ssl.network-config.v1'
+
+/**
+ * Default network config used when storage is missing or corrupt
+ */
+export const DEFAULT_NETWORK_CONFIG: NetworkConfig = DEFAULT_NETWORKS.futurenet
+
+/**
+ * Persisted state shape (only networkConfig)
+ */
+export interface PersistedState {
+  networkConfig: NetworkConfig
+}
+
+/**
+ * Validates that a value is a valid NetworkConfig object
+ */
+export function isValidNetworkConfig(value: unknown): value is NetworkConfig {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const config = value as Record<string, unknown>
+
+  return (
+    typeof config.networkId === 'string' &&
+    typeof config.networkPassphrase === 'string' &&
+    typeof config.rpcUrl === 'string' &&
+    config.networkId.length > 0 &&
+    config.networkPassphrase.length > 0 &&
+    config.rpcUrl.length > 0
+  )
+}
+
+/**
+ * Safe localStorage wrapper that handles errors gracefully
+ */
+const safeLocalStorage = {
+  getItem: (name: string): string | null => {
+    try {
+      if (typeof window === 'undefined') {
+        return null
+      }
+      return localStorage.getItem(name)
+    } catch {
+      console.warn(`[LensStore] Failed to read from localStorage: ${name}`)
+      return null
+    }
+  },
+
+  setItem: (name: string, value: string): void => {
+    try {
+      if (typeof window === 'undefined') {
+        return
+      }
+      localStorage.setItem(name, value)
+    } catch {
+      console.warn(`[LensStore] Failed to write to localStorage: ${name}`)
+    }
+  },
+
+  removeItem: (name: string): void => {
+    try {
+      if (typeof window === 'undefined') {
+        return
+      }
+      localStorage.removeItem(name)
+    } catch {
+      console.warn(`[LensStore] Failed to remove from localStorage: ${name}`)
+    }
+  },
+}
+
+/**
+ * Create safe storage for persist middleware
+ */
+export const createSafeStorage = <T>(): PersistStorage<T> | undefined =>
+  createJSONStorage<T>(() => safeLocalStorage)
+
+/**
+ * Hydration merge function that validates persisted data
+ * Returns default config if persisted data is invalid
+ */
+export function mergeNetworkConfig(
+  persistedState: unknown,
+  currentState: { networkConfig: NetworkConfig }
+): { networkConfig: NetworkConfig } {
+  if (
+    typeof persistedState === 'object' &&
+    persistedState !== null &&
+    'networkConfig' in persistedState
+  ) {
+    const persisted = persistedState as { networkConfig: unknown }
+
+    if (isValidNetworkConfig(persisted.networkConfig)) {
+      return { networkConfig: persisted.networkConfig }
+    }
+  }
+
+  // Return current state (with defaults) if persisted data is invalid
+  return currentState
+}
+
+/**
+ * Clear persisted network config (for testing)
+ */
+export function clearPersistedNetworkConfig(): void {
+  try {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(NETWORK_CONFIG_STORAGE_KEY)
+    }
+  } catch {
+    // Ignore errors during cleanup
+  }
+}

--- a/src/test/store/persistence.test.ts
+++ b/src/test/store/persistence.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  DEFAULT_NETWORK_CONFIG,
+  NETWORK_CONFIG_STORAGE_KEY,
+  clearPersistedNetworkConfig,
+  isValidNetworkConfig,
+  mergeNetworkConfig,
+} from '../../store/persistence'
+import { DEFAULT_NETWORKS } from '../../store/types'
+
+describe('persistence', () => {
+  beforeEach(() => {
+    // Clear localStorage before each test
+    clearPersistedNetworkConfig()
+    vi.clearAllMocks()
+  })
+
+  describe('NETWORK_CONFIG_STORAGE_KEY', () => {
+    it('has correct storage key format', () => {
+      expect(NETWORK_CONFIG_STORAGE_KEY).toBe('ssl.network-config.v1')
+    })
+  })
+
+  describe('DEFAULT_NETWORK_CONFIG', () => {
+    it('defaults to futurenet', () => {
+      expect(DEFAULT_NETWORK_CONFIG).toEqual(DEFAULT_NETWORKS.futurenet)
+    })
+
+    it('has valid network config structure', () => {
+      expect(isValidNetworkConfig(DEFAULT_NETWORK_CONFIG)).toBe(true)
+    })
+  })
+
+  describe('isValidNetworkConfig', () => {
+    it('returns true for valid network config', () => {
+      const validConfig = {
+        networkId: 'testnet',
+        networkPassphrase: 'Test Network',
+        rpcUrl: 'https://rpc.test.com',
+      }
+      expect(isValidNetworkConfig(validConfig)).toBe(true)
+    })
+
+    it('returns true for config with optional horizonUrl', () => {
+      const validConfig = {
+        networkId: 'mainnet',
+        networkPassphrase: 'Public Network',
+        rpcUrl: 'https://rpc.main.com',
+        horizonUrl: 'https://horizon.main.com',
+      }
+      expect(isValidNetworkConfig(validConfig)).toBe(true)
+    })
+
+    it('returns false for null', () => {
+      expect(isValidNetworkConfig(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isValidNetworkConfig(undefined)).toBe(false)
+    })
+
+    it('returns false for non-object', () => {
+      expect(isValidNetworkConfig('string')).toBe(false)
+      expect(isValidNetworkConfig(123)).toBe(false)
+      expect(isValidNetworkConfig(true)).toBe(false)
+    })
+
+    it('returns false when networkId is missing', () => {
+      const config = {
+        networkPassphrase: 'Test Network',
+        rpcUrl: 'https://rpc.test.com',
+      }
+      expect(isValidNetworkConfig(config)).toBe(false)
+    })
+
+    it('returns false when networkPassphrase is missing', () => {
+      const config = {
+        networkId: 'testnet',
+        rpcUrl: 'https://rpc.test.com',
+      }
+      expect(isValidNetworkConfig(config)).toBe(false)
+    })
+
+    it('returns false when rpcUrl is missing', () => {
+      const config = {
+        networkId: 'testnet',
+        networkPassphrase: 'Test Network',
+      }
+      expect(isValidNetworkConfig(config)).toBe(false)
+    })
+
+    it('returns false when networkId is empty string', () => {
+      const config = {
+        networkId: '',
+        networkPassphrase: 'Test Network',
+        rpcUrl: 'https://rpc.test.com',
+      }
+      expect(isValidNetworkConfig(config)).toBe(false)
+    })
+
+    it('returns false when values are wrong type', () => {
+      const config = {
+        networkId: 123,
+        networkPassphrase: 'Test Network',
+        rpcUrl: 'https://rpc.test.com',
+      }
+      expect(isValidNetworkConfig(config)).toBe(false)
+    })
+  })
+
+  describe('mergeNetworkConfig', () => {
+    const currentState = { networkConfig: DEFAULT_NETWORK_CONFIG }
+
+    it('returns persisted config when valid', () => {
+      const persistedState = {
+        networkConfig: DEFAULT_NETWORKS.testnet,
+      }
+      const result = mergeNetworkConfig(persistedState, currentState)
+      expect(result.networkConfig).toEqual(DEFAULT_NETWORKS.testnet)
+    })
+
+    it('returns current state when persisted state is null', () => {
+      const result = mergeNetworkConfig(null, currentState)
+      expect(result.networkConfig).toEqual(DEFAULT_NETWORK_CONFIG)
+    })
+
+    it('returns current state when persisted state is undefined', () => {
+      const result = mergeNetworkConfig(undefined, currentState)
+      expect(result.networkConfig).toEqual(DEFAULT_NETWORK_CONFIG)
+    })
+
+    it('returns current state when persisted networkConfig is invalid', () => {
+      const persistedState = {
+        networkConfig: { invalid: 'data' },
+      }
+      const result = mergeNetworkConfig(persistedState, currentState)
+      expect(result.networkConfig).toEqual(DEFAULT_NETWORK_CONFIG)
+    })
+
+    it('returns current state when persisted state has no networkConfig', () => {
+      const persistedState = {
+        someOtherData: 'value',
+      }
+      const result = mergeNetworkConfig(persistedState, currentState)
+      expect(result.networkConfig).toEqual(DEFAULT_NETWORK_CONFIG)
+    })
+
+    it('returns current state when persisted state is corrupt JSON', () => {
+      const persistedState = 'not an object'
+      const result = mergeNetworkConfig(persistedState, currentState)
+      expect(result.networkConfig).toEqual(DEFAULT_NETWORK_CONFIG)
+    })
+  })
+
+  describe('clearPersistedNetworkConfig', () => {
+    it('removes the storage key', () => {
+      // Set a value first
+      localStorage.setItem(NETWORK_CONFIG_STORAGE_KEY, JSON.stringify({ test: true }))
+      expect(localStorage.getItem(NETWORK_CONFIG_STORAGE_KEY)).not.toBeNull()
+
+      // Clear it
+      clearPersistedNetworkConfig()
+      expect(localStorage.getItem(NETWORK_CONFIG_STORAGE_KEY)).toBeNull()
+    })
+
+    it('does not throw when key does not exist', () => {
+      expect(() => clearPersistedNetworkConfig()).not.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
Summary
Adds Zustand persist middleware for the networkConfig slice only, allowing network selection to survive browser reloads while keeping heavy ledger data transient.

Changes
Persistence Module (src/store/persistence.ts):

NETWORK_CONFIG_STORAGE_KEY: "ssl.network-config.v1"
isValidNetworkConfig(): Validates persisted data structure
mergeNetworkConfig(): Safe hydration with fallback to defaults
createSafeStorage(): Error-tolerant localStorage wrapper
clearPersistedNetworkConfig(): Test utility
Store Updates (src/store/lensStore.ts):

Added persist middleware from zustand/middleware
partialize: Only persists networkConfig slice
merge: Validates and safely merges persisted data

close #34 