### PR TITLE
feat: implement typed RPC client for network interactions

### DIFF
--- a/src/lib/network/rpcClient.ts
+++ b/src/lib/network/rpcClient.ts
@@ -1,0 +1,64 @@
+import type { RpcConfig, RpcError } from './types';
+
+export async function callRpc<T = unknown>(
+  config: RpcConfig,
+  body?: unknown
+): Promise<T | RpcError> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), config.timeout);
+
+  try {
+    const response = await fetch(config.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...config.headers,
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => 'Unknown error');
+      return {
+        message: `HTTP ${response.status}: ${response.statusText}`,
+        code: response.status,
+        details: errorText,
+        isTimeout: false,
+      };
+    }
+
+    const data = await response.json();
+    return data as T;
+  } catch (error) {
+    clearTimeout(timeoutId);
+
+    if ((error instanceof Error && error.name === 'AbortError') || 
+        (error instanceof DOMException && error.name === 'AbortError')) {
+      return {
+        message: 'Request timeout',
+        code: 'TIMEOUT',
+        details: `Request timed out after ${config.timeout}ms`,
+        isTimeout: true,
+      };
+    }
+
+    if (error instanceof TypeError && error.message.includes('fetch')) {
+      return {
+        message: 'Network error',
+        code: 'NETWORK_ERROR',
+        details: error.message,
+        isTimeout: false,
+      };
+    }
+
+    return {
+      message: error instanceof Error ? error.message : 'Unknown error',
+      code: 'UNKNOWN_ERROR',
+      details: error,
+      isTimeout: false,
+    };
+  }
+}

--- a/src/lib/network/types.ts
+++ b/src/lib/network/types.ts
@@ -1,0 +1,12 @@
+export interface RpcConfig {
+  url: string;
+  timeout: number;
+  headers?: Record<string, string>;
+}
+
+export interface RpcError {
+  message: string;
+  code?: string | number;
+  details?: unknown;
+  isTimeout?: boolean;
+}

--- a/src/test/network/rpcClient.test.ts
+++ b/src/test/network/rpcClient.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { callRpc } from '../../lib/network/rpcClient';
+import type { RpcConfig } from '../../lib/network/types';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe('callRpc', () => {
+  const defaultConfig: RpcConfig = {
+    url: 'https://api.example.com/rpc',
+    timeout: 5000,
+    headers: { 'X-Custom': 'test' },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should handle successful responses', async () => {
+    const mockData = { result: 'success', id: 123 };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
+    });
+
+    const result = await callRpc<typeof mockData>(defaultConfig, { method: 'test' });
+
+    expect(result).toEqual(mockData);
+    expect(mockFetch).toHaveBeenCalledWith(defaultConfig.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Custom': 'test',
+      },
+      body: JSON.stringify({ method: 'test' }),
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it('should handle HTTP errors', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: () => Promise.resolve('Resource not found'),
+    });
+
+    const result = await callRpc(defaultConfig);
+
+    expect(result).toMatchObject({
+      message: 'HTTP 404: Not Found',
+      code: 404,
+      details: 'Resource not found',
+      isTimeout: false,
+    });
+  });
+
+  it('should handle network errors', async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    const result = await callRpc(defaultConfig);
+
+    expect(result).toMatchObject({
+      message: 'Network error',
+      code: 'NETWORK_ERROR',
+      details: 'Failed to fetch',
+      isTimeout: false,
+    });
+  });
+
+  it('should handle timeout errors', async () => {
+    mockFetch.mockRejectedValueOnce(new DOMException('The operation was aborted.', 'AbortError'));
+
+    const result = await callRpc({ ...defaultConfig, timeout: 1000 });
+
+    expect(result).toMatchObject({
+      message: 'Request timeout',
+      code: 'TIMEOUT',
+      details: 'Request timed out after 1000ms',
+      isTimeout: true,
+    });
+  });
+
+  it('should work without body parameter', async () => {
+    const mockData = { status: 'ok' };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
+    });
+
+    const result = await callRpc(defaultConfig);
+
+    expect(result).toEqual(mockData);
+    expect(mockFetch).toHaveBeenCalledWith(defaultConfig.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Custom': 'test',
+      },
+      body: undefined,
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it('should work without optional headers', async () => {
+    const configWithoutHeaders: RpcConfig = {
+      url: 'https://api.example.com/rpc',
+      timeout: 5000,
+    };
+    
+    const mockData = { result: 'success' };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
+    });
+
+    const result = await callRpc(configWithoutHeaders);
+
+    expect(result).toEqual(mockData);
+    expect(mockFetch).toHaveBeenCalledWith(configWithoutHeaders.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: undefined,
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it('should handle JSON parsing errors', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.reject(new Error('Invalid JSON')),
+    });
+
+    const result = await callRpc(defaultConfig);
+
+    expect(result).toMatchObject({
+      message: 'Invalid JSON',
+      code: 'UNKNOWN_ERROR',
+      isTimeout: false,
+    });
+  });
+});


### PR DESCRIPTION
Close #28 
- Add RpcConfig interface with url, timeout, and optional headers
- Add RpcError interface for standardized error handling
- Implement callRpc helper with TypeScript generics
- Add timeout handling using AbortController
- Implement normalized error mapping for different failure types
- Add comprehensive unit tests with mocked fetch responses
- All verification steps pass (lint, build, test)

Resolves: 11 (child task)