### PR TITLE
Feat: Added classifyRpcHttpStatus

### DIFF
--- a/src/lib/rpc/classifyRpcHttpStatus.ts
+++ b/src/lib/rpc/classifyRpcHttpStatus.ts
@@ -1,0 +1,35 @@
+/**
+ * Classifies HTTP status codes for RPC failures to determine the retry strategy.
+ *
+ * Classification Logic:
+ * - 'retryable': Status code 429 (Too Many Requests) or 5xx (Server Errors).
+ * - 'fatal': Status code 4xx (Client Errors) excluding 429.
+ * - 'unknown': All other status codes, including non-integer or negative values.
+ *
+ * @param status The HTTP status code to classify.
+ * @returns 'retryable', 'fatal', or 'unknown'.
+ */
+export function classifyRpcHttpStatus(status: number): 'retryable' | 'fatal' | 'unknown' {
+  // Handle non-integer and negative values as unknown
+  if (!Number.isInteger(status) || status < 0) {
+    return 'unknown';
+  }
+
+  // 429 is retryable (rate limited)
+  if (status === 429) {
+    return 'retryable';
+  }
+
+  // 5xx are retryable (server errors)
+  if (status >= 500 && status < 600) {
+    return 'retryable';
+  }
+
+  // Other 4xx are fatal (client errors)
+  if (status >= 400 && status < 500) {
+    return 'fatal';
+  }
+
+  // All other cases (2xx, 1xx, 3xx) are unknown in the context of an RPC failure classification
+  return 'unknown';
+}

--- a/src/test/rpc/classifyRpcHttpStatus.test.ts
+++ b/src/test/rpc/classifyRpcHttpStatus.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { classifyRpcHttpStatus } from '../../lib/rpc/classifyRpcHttpStatus';
+
+describe('classifyRpcHttpStatus', () => {
+  it('should return "retryable" for status 429', () => {
+    expect(classifyRpcHttpStatus(429)).toBe('retryable');
+  });
+
+  it('should return "retryable" for 5xx status codes', () => {
+    expect(classifyRpcHttpStatus(500)).toBe('retryable');
+    expect(classifyRpcHttpStatus(503)).toBe('retryable');
+    expect(classifyRpcHttpStatus(504)).toBe('retryable');
+    expect(classifyRpcHttpStatus(599)).toBe('retryable');
+  });
+
+  it('should return "fatal" for 4xx status codes except 429', () => {
+    expect(classifyRpcHttpStatus(400)).toBe('fatal');
+    expect(classifyRpcHttpStatus(401)).toBe('fatal');
+    expect(classifyRpcHttpStatus(403)).toBe('fatal');
+    expect(classifyRpcHttpStatus(404)).toBe('fatal');
+    expect(classifyRpcHttpStatus(499)).toBe('fatal');
+  });
+
+  it('should return "unknown" for 2xx and 3xx status codes', () => {
+    expect(classifyRpcHttpStatus(200)).toBe('unknown');
+    expect(classifyRpcHttpStatus(201)).toBe('unknown');
+    expect(classifyRpcHttpStatus(301)).toBe('unknown');
+    expect(classifyRpcHttpStatus(302)).toBe('unknown');
+  });
+
+  it('should return "unknown" for non-integer values', () => {
+    expect(classifyRpcHttpStatus(429.5)).toBe('unknown');
+    expect(classifyRpcHttpStatus(500.1)).toBe('unknown');
+    expect(classifyRpcHttpStatus(NaN)).toBe('unknown');
+    expect(classifyRpcHttpStatus(Infinity)).toBe('unknown');
+  });
+
+  it('should return "unknown" for negative values', () => {
+    expect(classifyRpcHttpStatus(-1)).toBe('unknown');
+    expect(classifyRpcHttpStatus(-500)).toBe('unknown');
+  });
+
+  it('should return "unknown" for zero', () => {
+    expect(classifyRpcHttpStatus(0)).toBe('unknown');
+  });
+});


### PR DESCRIPTION
Task Completed - RPC HTTP Status Classifier
I have implemented an RPC HTTP status classifier and verified it with unit tests.

Added: classifyRpcHttpStatus.ts
Created a new utility : classifyRpcHttpStatus(status: number) to categorize HTTP responses for RPC retry logic.

Classification Logic:
retryable: Status 429 (Rate Limit) or 5xx (Server Error).
fatal: Status 4xx (Client Error) excluding 429.
unknown: Non-numeric, negative, or other unexpected status codes.
[Tests]
classifyRpcHttpStatus.test.ts

closes: #70 
