### PR TITLE
feat: added parent Tree Node Path helper

### DIFF
--- a/src/lib/tree/parentTreeNodePath.ts
+++ b/src/lib/tree/parentTreeNodePath.ts
@@ -1,0 +1,25 @@
+/**
+ * Returns the immediate parent path for a given tree node path.
+ * Paths use dot notation (e.g., 'a.b.c').
+ * Dots can be escaped with a backslash (e.g., 'a.b\.c') to be treated as part of the node name.
+ *
+ * @param path The node path to find the parent for.
+ * @returns {string | null} The parent path, or null if the path is at the root or invalid.
+ */
+export function parentTreeNodePath(path: string): string | null {
+  if (!path) {
+    return null
+  }
+
+  // Find all dots that are NOT preceded by a backslash
+  // We use a lookbehind assertion to ensure we only split on unescaped dots
+  const segments = path.split(/(?<!\\)\./)
+
+  // If there's only one segment (or none), there is no parent
+  if (segments.length <= 1) {
+    return null
+  }
+
+  // Re-join all segments except the last one
+  return segments.slice(0, -1).join('.')
+}

--- a/src/test/tree/parentTreeNodePath.test.ts
+++ b/src/test/tree/parentTreeNodePath.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { parentTreeNodePath } from '../../lib/tree/parentTreeNodePath'
+
+describe('parentTreeNodePath', () => {
+  it('should return the immediate parent path for a normal path', () => {
+    expect(parentTreeNodePath('a.b.c')).toBe('a.b')
+    expect(parentTreeNodePath('root.child')).toBe('root')
+    expect(parentTreeNodePath('1.2.3.4')).toBe('1.2.3')
+  })
+
+  it('should handle escaped dots correctly', () => {
+    expect(parentTreeNodePath('a.b\\.c.d')).toBe('a.b\\.c')
+    expect(parentTreeNodePath('a\\.b.c')).toBe('a\\.b')
+    expect(parentTreeNodePath('a.b\\.c')).toBe('a')
+  })
+
+  it('should return null for top-level nodes (no parent)', () => {
+    expect(parentTreeNodePath('a')).toBeNull()
+    expect(parentTreeNodePath('root')).toBeNull()
+    expect(parentTreeNodePath('node-with-escaped\\.dot')).toBeNull()
+  })
+
+  it('should return null for invalid or empty input', () => {
+    expect(parentTreeNodePath('')).toBeNull()
+    // @ts-ignore - testing invalid input types
+    expect(parentTreeNodePath(null)).toBeNull()
+    // @ts-ignore - testing invalid input types
+    expect(parentTreeNodePath(undefined)).toBeNull()
+  })
+
+  it('should handle multiple escaped dots', () => {
+    expect(parentTreeNodePath('a\\.b\\.c.d')).toBe('a\\.b\\.c')
+    expect(parentTreeNodePath('a.b\\.c\\.d')).toBe('a')
+  })
+
+  it('should handle paths with special characters', () => {
+    expect(parentTreeNodePath('node-1.node_2.node$3')).toBe('node-1.node_2')
+  })
+})


### PR DESCRIPTION
Task Completed - Implement parentTreeNodePath Helper
I have implemented a minimal helper to navigate up one tree level, handling escaped dots.

Splits a dot-notated path into segments.
Uses a regex lookbehind 
(?<!\).
 to ignore escaped dots.
Returns the parent path by joining all segments except the last one.
Returns null if the node is at the root level or if the input is empty/invalid.

To close: #87 