### PR TITLE
feat: added Tree Node Path Parser helper

### DIFF
--- a/src/lib/tree/parseTreeNodePath.ts
+++ b/src/lib/tree/parseTreeNodePath.ts
@@ -1,0 +1,46 @@
+/**
+ * Decodes a dot-joined escaped path back into its original parts.
+ * Escapes are handled using a backslash (\). For example, "a\.b" becomes ["a.b"].
+ * If an invalid escape sequence is encountered (e.g., a trailing backslash), an empty array is returned.
+ *
+ * @param path - The dot-joined escaped path string.
+ * @returns An array of decoded path segments, or an empty array if invalid.
+ */
+export function parseTreeNodePath(path: string): Array<string> {
+  if (path === '') {
+    return []
+  }
+
+  const parts: Array<string> = []
+  let currentPart = ''
+  let i = 0
+
+  while (i < path.length) {
+    const char = path[i]
+
+    if (char === '\\') {
+      // Check if there's a character to escape
+      if (i + 1 >= path.length) {
+        // Invalid escape sequence: trailing backslash
+        return []
+      }
+      // Escaped character - append the next character directly
+      currentPart += path[i + 1]
+      i += 2
+    } else if (char === '.') {
+      // Separator - push current part and reset
+      parts.push(currentPart)
+      currentPart = ''
+      i++
+    } else {
+      // Normal character
+      currentPart += char
+      i++
+    }
+  }
+
+  // Push the last part
+  parts.push(currentPart)
+
+  return parts
+}

--- a/src/test/tree/parseTreeNodePath.test.ts
+++ b/src/test/tree/parseTreeNodePath.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { parseTreeNodePath } from '../../lib/tree/parseTreeNodePath'
+
+describe('parseTreeNodePath', () => {
+  it('should decode a simple dot-joined path', () => {
+    expect(parseTreeNodePath('a.b.c')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('should handle escaped dots', () => {
+    expect(parseTreeNodePath('a\\.b.c')).toEqual(['a.b', 'c'])
+    expect(parseTreeNodePath('a.b\\.c')).toEqual(['a', 'b.c'])
+    expect(parseTreeNodePath('a\\.b\\.c')).toEqual(['a.b.c'])
+  })
+
+  it('should handle escaped backslashes', () => {
+    expect(parseTreeNodePath('a\\\\.b')).toEqual(['a\\', 'b'])
+    expect(parseTreeNodePath('a\\\\\\.b')).toEqual(['a\\.b'])
+  })
+
+  it('should return an empty array for invalid escape sequences', () => {
+    // Trailing backslash is invalid
+    expect(parseTreeNodePath('a.b\\')).toEqual([])
+    expect(parseTreeNodePath('a\\')).toEqual([])
+    expect(parseTreeNodePath('\\')).toEqual([])
+  })
+
+  it('should handle empty string as empty path', () => {
+    expect(parseTreeNodePath('')).toEqual([])
+  })
+
+  it('should handle multiple consecutive dots (empty segments)', () => {
+    expect(parseTreeNodePath('a..b')).toEqual(['a', '', 'b'])
+    expect(parseTreeNodePath('.')).toEqual(['', ''])
+    expect(parseTreeNodePath('..')).toEqual(['', '', ''])
+  })
+
+  it('should handle paths with special characters', () => {
+    expect(parseTreeNodePath('user@domain.com/path')).toEqual([
+      'user@domain',
+      'com/path',
+    ])
+    expect(parseTreeNodePath('a\\ b')).toEqual(['a b'])
+  })
+
+  it('should handle complex mixed cases', () => {
+    expect(parseTreeNodePath('a\\.b\\\\.c\\..d')).toEqual(['a.b\\', 'c.', 'd'])
+  })
+})


### PR DESCRIPTION
Task Completed - Implement parseTreeNodePath Helper
I have implemented a reliable decoder for dot-joined escaped tree node paths, ensuring consistency with the expected reversed logic of path building.

Implemented 
parseTreeNodePath(path: string): string[]
 which:

Uses a character-by-character scanner to correctly handle escaped characters (via \) and separators (via .).
Correctly decodes escaped dots (\.) and escaped backslashes (\\).
Returns an empty array [] for invalid escape sequences (like a trailing backslash).
Treats an empty string "" as an empty path [].

Closes: #86 