### PR TITLE
feat(storage): add makeLedgerEntryKey helper for ledger entry keys

### DIFF
--- a/src/lib/storage/makeLedgerEntryKey.ts
+++ b/src/lib/storage/makeLedgerEntryKey.ts
@@ -1,0 +1,33 @@
+/**
+ * Builds a stable, sanitized ledger entry map key.
+ *
+ * Format: `contract::entryType::keyPart`
+ *
+ * Requirements:
+ * - Each component is trimmed before joining.
+ * - Throws an Error if any component is empty after trimming.
+ * - Returns a deterministic string suitable for use as a map key.
+ *
+ * @param contractId The contract identifier.
+ * @param entryType The ledger entry type.
+ * @param keyPart The specific key part within the entry.
+ * @returns A formatted ledger entry key string.
+ */
+export function makeLedgerEntryKey(
+  contractId: string,
+  entryType: string,
+  keyPart: string,
+): string {
+  const trimmedContract = sanitize(contractId, 'contractId')
+  const trimmedType = sanitize(entryType, 'entryType')
+  const trimmedKey = sanitize(keyPart, 'keyPart')
+
+  return `${trimmedContract}::${trimmedType}::${trimmedKey}`
+}
+
+function sanitize(value: string, name: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${name} must be a non-empty string`)
+  }
+  return value.trim()
+}

--- a/src/test/storage/makeLedgerEntryKey.test.ts
+++ b/src/test/storage/makeLedgerEntryKey.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { makeLedgerEntryKey } from '../../lib/storage/makeLedgerEntryKey'
+
+describe('makeLedgerEntryKey', () => {
+  it('should build a key in contract::entryType::keyPart format', () => {
+    expect(makeLedgerEntryKey('CABC', 'persistent', 'balance')).toBe(
+      'CABC::persistent::balance',
+    )
+  })
+
+  it('should trim whitespace from all components', () => {
+    expect(makeLedgerEntryKey('  CABC  ', ' persistent ', ' balance ')).toBe(
+      'CABC::persistent::balance',
+    )
+  })
+
+  it('should handle various valid inputs', () => {
+    expect(makeLedgerEntryKey('C123', 'temporary', 'counter')).toBe(
+      'C123::temporary::counter',
+    )
+    expect(makeLedgerEntryKey('CDEF', 'instance', 'admin')).toBe(
+      'CDEF::instance::admin',
+    )
+  })
+
+  it('should throw for empty contractId', () => {
+    expect(() => makeLedgerEntryKey('', 'persistent', 'balance')).toThrow(
+      'contractId must be a non-empty string',
+    )
+  })
+
+  it('should throw for empty entryType', () => {
+    expect(() => makeLedgerEntryKey('CABC', '', 'balance')).toThrow(
+      'entryType must be a non-empty string',
+    )
+  })
+
+  it('should throw for empty keyPart', () => {
+    expect(() => makeLedgerEntryKey('CABC', 'persistent', '')).toThrow(
+      'keyPart must be a non-empty string',
+    )
+  })
+
+  it('should throw for whitespace-only components', () => {
+    expect(() => makeLedgerEntryKey('   ', 'persistent', 'balance')).toThrow(
+      'contractId must be a non-empty string',
+    )
+    expect(() => makeLedgerEntryKey('CABC', '  ', 'balance')).toThrow(
+      'entryType must be a non-empty string',
+    )
+    expect(() => makeLedgerEntryKey('CABC', 'persistent', '\t')).toThrow(
+      'keyPart must be a non-empty string',
+    )
+  })
+
+  it('should throw for non-string types at runtime', () => {
+    // @ts-ignore - testing runtime behavior
+    expect(() => makeLedgerEntryKey(null, 'persistent', 'balance')).toThrow()
+    // @ts-ignore - testing runtime behavior
+    expect(() => makeLedgerEntryKey('CABC', undefined, 'balance')).toThrow()
+    // @ts-ignore - testing runtime behavior
+    expect(() => makeLedgerEntryKey('CABC', 'persistent', 123)).toThrow()
+  })
+
+  it('should produce deterministic output for the same inputs', () => {
+    const a = makeLedgerEntryKey('CABC', 'persistent', 'balance')
+    const b = makeLedgerEntryKey('CABC', 'persistent', 'balance')
+    expect(a).toBe(b)
+  })
+})


### PR DESCRIPTION
- Add makeLedgerEntryKey function to build stable, sanitized ledger entry map keys
- Implement sanitize helper to validate and trim string components
- Use deterministic format: contract::entryType::keyPart
- Add comprehensive test suite covering valid inputs, whitespace trimming, and error cases
- Validate all components are non-empty strings after trimming

closes #75 