### PR TITLE
feat(storage): add ledger entry key parser

### DIFF
--- a/src/lib/storage/parseLedgerEntryKey.ts
+++ b/src/lib/storage/parseLedgerEntryKey.ts
@@ -1,0 +1,37 @@
+/**
+ * Parses a serialized ledger entry key back into its components.
+ *
+ * Expected format: `contractId::entryType::keyPart`
+ *
+ * Requirements:
+ * - Returns the three components as an object, or null if malformed.
+ * - Rejects keys with extra separators (more than 3 segments).
+ * - Rejects keys with blank segments after trimming.
+ * - Rejects empty or non-string input.
+ *
+ * @param key The serialized ledger entry key string.
+ * @returns Parsed components or null if the key is malformed.
+ */
+export function parseLedgerEntryKey(
+  key: string,
+): { contractId: string; entryType: string; keyPart: string } | null {
+  if (typeof key !== 'string' || key.trim() === '') {
+    return null
+  }
+
+  const parts = key.split('::')
+
+  if (parts.length !== 3) {
+    return null
+  }
+
+  const contractId = parts[0].trim()
+  const entryType = parts[1].trim()
+  const keyPart = parts[2].trim()
+
+  if (contractId === '' || entryType === '' || keyPart === '') {
+    return null
+  }
+
+  return { contractId, entryType, keyPart }
+}

--- a/src/test/storage/parseLedgerEntryKey.test.ts
+++ b/src/test/storage/parseLedgerEntryKey.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { parseLedgerEntryKey } from '../../lib/storage/parseLedgerEntryKey'
+
+describe('parseLedgerEntryKey', () => {
+  it('should parse a valid key into its components', () => {
+    expect(parseLedgerEntryKey('CABC::persistent::balance')).toEqual({
+      contractId: 'CABC',
+      entryType: 'persistent',
+      keyPart: 'balance',
+    })
+  })
+
+  it('should handle various valid keys', () => {
+    expect(parseLedgerEntryKey('C123::temporary::counter')).toEqual({
+      contractId: 'C123',
+      entryType: 'temporary',
+      keyPart: 'counter',
+    })
+    expect(parseLedgerEntryKey('CDEF::instance::admin')).toEqual({
+      contractId: 'CDEF',
+      entryType: 'instance',
+      keyPart: 'admin',
+    })
+  })
+
+  it('should trim whitespace from segments', () => {
+    expect(parseLedgerEntryKey(' CABC :: persistent :: balance ')).toEqual({
+      contractId: 'CABC',
+      entryType: 'persistent',
+      keyPart: 'balance',
+    })
+  })
+
+  it('should return null for keys with extra separators', () => {
+    expect(parseLedgerEntryKey('CABC::persistent::balance::extra')).toBeNull()
+    expect(
+      parseLedgerEntryKey('CABC::persistent::balance::extra::more'),
+    ).toBeNull()
+  })
+
+  it('should return null for keys with too few segments', () => {
+    expect(parseLedgerEntryKey('CABC::persistent')).toBeNull()
+    expect(parseLedgerEntryKey('CABC')).toBeNull()
+  })
+
+  it('should return null for blank segments', () => {
+    expect(parseLedgerEntryKey('::persistent::balance')).toBeNull()
+    expect(parseLedgerEntryKey('CABC::::balance')).toBeNull()
+    expect(parseLedgerEntryKey('CABC::persistent::')).toBeNull()
+  })
+
+  it('should return null for whitespace-only segments', () => {
+    expect(parseLedgerEntryKey('   ::persistent::balance')).toBeNull()
+    expect(parseLedgerEntryKey('CABC::   ::balance')).toBeNull()
+    expect(parseLedgerEntryKey('CABC::persistent::   ')).toBeNull()
+  })
+
+  it('should return null for empty string', () => {
+    expect(parseLedgerEntryKey('')).toBeNull()
+  })
+
+  it('should return null for whitespace-only string', () => {
+    expect(parseLedgerEntryKey('   ')).toBeNull()
+    expect(parseLedgerEntryKey('\t')).toBeNull()
+  })
+
+  it('should return null for non-string types at runtime', () => {
+    // @ts-ignore - testing runtime behavior
+    expect(parseLedgerEntryKey(null)).toBeNull()
+    // @ts-ignore - testing runtime behavior
+    expect(parseLedgerEntryKey(undefined)).toBeNull()
+    // @ts-ignore - testing runtime behavior
+    expect(parseLedgerEntryKey(123)).toBeNull()
+  })
+
+  it('should roundtrip with makeLedgerEntryKey format', () => {
+    const key = 'CABC::persistent::balance'
+    const parsed = parseLedgerEntryKey(key)
+    expect(parsed).toEqual({
+      contractId: 'CABC',
+      entryType: 'persistent',
+      keyPart: 'balance',
+    })
+    expect(
+      `${parsed!.contractId}::${parsed!.entryType}::${parsed!.keyPart}`,
+    ).toBe(key)
+  })
+})


### PR DESCRIPTION
- Add parseLedgerEntryKey function to deserialize ledger entry keys
- Parse keys in format `contractId::entryType::keyPart` into components
- Validate key structure and reject malformed inputs (extra separators, blank segments)
- Trim whitespace from all segments during parsing
- Add comprehensive test suite covering valid keys, edge cases, and error conditions
- Enables roundtrip serialization/deserialization with makeLedgerEntryKey

Closes #76 