### PR TITLE
feat(storage): add network config sanitizer with validation

### DIFF
--- a/src/lib/storage/sanitizePersistedNetworkConfig.ts
+++ b/src/lib/storage/sanitizePersistedNetworkConfig.ts
@@ -1,0 +1,52 @@
+import { DEFAULT_NETWORKS } from '../../store/types'
+import type { NetworkConfig } from '../../store/types'
+
+const FALLBACK: NetworkConfig = DEFAULT_NETWORKS.futurenet
+
+/**
+ * Sanitizes an unknown persisted value into a safe NetworkConfig.
+ *
+ * Requirements:
+ * - Returns a NetworkConfig with all required fields populated.
+ * - Falls back to DEFAULT_NETWORKS.futurenet values for missing or invalid fields.
+ * - Strips unknown keys not part of NetworkConfig.
+ * - Coerces non-string or empty fields to the futurenet defaults.
+ * - Never mutates the input or shared config objects.
+ *
+ * @param input The raw persisted value (unknown shape).
+ * @returns A sanitized NetworkConfig with guaranteed valid fields.
+ */
+export function sanitizePersistedNetworkConfig(
+  input: unknown,
+): NetworkConfig {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    return { ...FALLBACK }
+  }
+
+  const raw = input as Record<string, unknown>
+
+  const networkId = isNonEmptyString(raw.networkId)
+    ? raw.networkId
+    : FALLBACK.networkId
+
+  const networkPassphrase = isNonEmptyString(raw.networkPassphrase)
+    ? raw.networkPassphrase
+    : FALLBACK.networkPassphrase
+
+  const rpcUrl = isNonEmptyString(raw.rpcUrl)
+    ? raw.rpcUrl
+    : FALLBACK.rpcUrl
+
+  return {
+    networkId,
+    networkPassphrase,
+    rpcUrl,
+    horizonUrl: isNonEmptyString(raw.horizonUrl)
+      ? raw.horizonUrl
+      : FALLBACK.horizonUrl,
+  }
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}

--- a/src/test/storage/sanitizePersistedNetworkConfig.test.ts
+++ b/src/test/storage/sanitizePersistedNetworkConfig.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { sanitizePersistedNetworkConfig } from '../../lib/storage/sanitizePersistedNetworkConfig'
+import { DEFAULT_NETWORKS } from '../../store/types'
+
+const FUTURENET = DEFAULT_NETWORKS.futurenet
+
+describe('sanitizePersistedNetworkConfig', () => {
+  it('should return a valid config when all fields are present', () => {
+    const input = {
+      networkId: 'testnet',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      rpcUrl: 'https://soroban-testnet.stellar.org',
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+    }
+    expect(sanitizePersistedNetworkConfig(input)).toEqual(input)
+  })
+
+  it('should fallback horizonUrl to futurenet default when not provided', () => {
+    const input = {
+      networkId: 'custom',
+      networkPassphrase: 'Custom Network',
+      rpcUrl: 'https://custom.example.com',
+    }
+    expect(sanitizePersistedNetworkConfig(input)).toEqual({
+      ...input,
+      horizonUrl: FUTURENET.horizonUrl,
+    })
+  })
+
+  it('should fallback to futurenet defaults for null input', () => {
+    expect(sanitizePersistedNetworkConfig(null)).toEqual(FUTURENET)
+  })
+
+  it('should fallback to futurenet defaults for undefined input', () => {
+    expect(sanitizePersistedNetworkConfig(undefined)).toEqual(FUTURENET)
+  })
+
+  it('should fallback to futurenet defaults for non-object input', () => {
+    expect(sanitizePersistedNetworkConfig('string')).toEqual(FUTURENET)
+    expect(sanitizePersistedNetworkConfig(123)).toEqual(FUTURENET)
+    expect(sanitizePersistedNetworkConfig(true)).toEqual(FUTURENET)
+  })
+
+  it('should fallback to futurenet defaults for array input', () => {
+    expect(sanitizePersistedNetworkConfig([])).toEqual(FUTURENET)
+    expect(sanitizePersistedNetworkConfig([1, 2, 3])).toEqual(FUTURENET)
+  })
+
+  it('should fallback to futurenet defaults for empty object', () => {
+    expect(sanitizePersistedNetworkConfig({})).toEqual(FUTURENET)
+  })
+
+  it('should coerce missing fields to futurenet defaults', () => {
+    const input = { networkId: 'mainnet' }
+    const result = sanitizePersistedNetworkConfig(input)
+    expect(result.networkId).toBe('mainnet')
+    expect(result.networkPassphrase).toBe(FUTURENET.networkPassphrase)
+    expect(result.rpcUrl).toBe(FUTURENET.rpcUrl)
+  })
+
+  it('should coerce non-string fields to futurenet defaults', () => {
+    const input = {
+      networkId: 42,
+      networkPassphrase: null,
+      rpcUrl: false,
+    }
+    expect(sanitizePersistedNetworkConfig(input)).toEqual(FUTURENET)
+  })
+
+  it('should coerce empty string fields to futurenet defaults', () => {
+    const input = {
+      networkId: '',
+      networkPassphrase: '  ',
+      rpcUrl: '',
+    }
+    expect(sanitizePersistedNetworkConfig(input)).toEqual(FUTURENET)
+  })
+
+  it('should strip unknown keys', () => {
+    const input = {
+      networkId: 'testnet',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      rpcUrl: 'https://soroban-testnet.stellar.org',
+      unknownKey: 'should be stripped',
+      anotherExtra: 42,
+    }
+    const result = sanitizePersistedNetworkConfig(input)
+    expect(result).toEqual({
+      networkId: 'testnet',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      rpcUrl: 'https://soroban-testnet.stellar.org',
+      horizonUrl: FUTURENET.horizonUrl,
+    })
+    expect('unknownKey' in result).toBe(false)
+    expect('anotherExtra' in result).toBe(false)
+  })
+
+  it('should fallback horizonUrl to futurenet default when invalid', () => {
+    const input = {
+      networkId: 'testnet',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      rpcUrl: 'https://soroban-testnet.stellar.org',
+      horizonUrl: 123,
+    }
+    const result = sanitizePersistedNetworkConfig(input)
+    expect(result.horizonUrl).toBe(FUTURENET.horizonUrl)
+  })
+
+  it('should not mutate the input object', () => {
+    const input = {
+      networkId: 'testnet',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      rpcUrl: 'https://soroban-testnet.stellar.org',
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+    }
+    const frozen = Object.freeze({ ...input })
+    const result = sanitizePersistedNetworkConfig(frozen)
+    expect(result).toEqual(input)
+    expect(result).not.toBe(frozen)
+  })
+
+  it('should not return a reference to the shared fallback config', () => {
+    const result = sanitizePersistedNetworkConfig(null)
+    expect(result).toEqual(FUTURENET)
+    expect(result).not.toBe(FUTURENET)
+  })
+})


### PR DESCRIPTION
- Add sanitizePersistedNetworkConfig function to safely coerce unknown persisted values into valid NetworkConfig objects
- Implement fallback to DEFAULT_NETWORKS.futurenet for missing or invalid fields
- Strip unknown keys not part of NetworkConfig schema
- Coerce non-string or empty fields to futurenet defaults
- Add isNonEmptyString helper to validate string fields
- Ensure function never mutates input or shared config objects
- Add comprehensive test suite covering all sanitization scenarios and edge cases

closes #79 