### PR TITLE
feat(selectors): Add selectLedgerEntriesByContractId selector

### DIFF
--- a/src/lib/selectors/selectLedgerEntriesByContractId.ts
+++ b/src/lib/selectors/selectLedgerEntriesByContractId.ts
@@ -1,0 +1,28 @@
+import type { LedgerEntry, LensStore } from '../../store/types'
+
+/**
+ * Selects all ledger entries matching a given contract ID.
+ *
+ * Requirements:
+ * - Filters ledgerData entries by exact contractId match.
+ * - Returns results sorted deterministically by entry key (ascending).
+ * - Returns an empty array for unknown, empty, or blank contract IDs.
+ *
+ * @param state The full LensStore state.
+ * @param contractId The contract ID to filter by.
+ * @returns Sorted array of matching LedgerEntry objects.
+ */
+export function selectLedgerEntriesByContractId(
+  state: LensStore,
+  contractId: string,
+): Array<LedgerEntry> {
+  if (typeof contractId !== 'string' || contractId.trim() === '') {
+    return []
+  }
+
+  const entries = Object.values(state.ledgerData).filter(
+    (entry) => entry.contractId === contractId,
+  )
+
+  return entries.sort((a, b) => a.key.localeCompare(b.key))
+}

--- a/src/test/selectors/selectLedgerEntriesByContractId.test.ts
+++ b/src/test/selectors/selectLedgerEntriesByContractId.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { selectLedgerEntriesByContractId } from '../../lib/selectors/selectLedgerEntriesByContractId'
+import type { LedgerEntry, LensStore } from '../../store/types'
+
+function makeEntry(overrides: Partial<LedgerEntry> & { key: string; contractId: string }): LedgerEntry {
+  return {
+    type: 'ContractData',
+    value: null,
+    lastModifiedLedger: 100,
+    ...overrides,
+  }
+}
+
+function makeState(entries: Array<LedgerEntry>): LensStore {
+  const ledgerData: Record<string, LedgerEntry> = {}
+  for (const entry of entries) {
+    ledgerData[entry.key] = entry
+  }
+  return { ledgerData } as unknown as LensStore
+}
+
+describe('selectLedgerEntriesByContractId', () => {
+  const entryA = makeEntry({ key: 'key-b', contractId: 'CABC' })
+  const entryB = makeEntry({ key: 'key-a', contractId: 'CABC' })
+  const entryC = makeEntry({ key: 'key-c', contractId: 'CXYZ' })
+
+  const state = makeState([entryA, entryB, entryC])
+
+  it('should return entries matching the given contractId', () => {
+    const result = selectLedgerEntriesByContractId(state, 'CABC')
+    expect(result).toHaveLength(2)
+    expect(result.every((e) => e.contractId === 'CABC')).toBe(true)
+  })
+
+  it('should sort results by key in ascending order', () => {
+    const result = selectLedgerEntriesByContractId(state, 'CABC')
+    expect(result[0].key).toBe('key-a')
+    expect(result[1].key).toBe('key-b')
+  })
+
+  it('should return a single entry when only one matches', () => {
+    const result = selectLedgerEntriesByContractId(state, 'CXYZ')
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(entryC)
+  })
+
+  it('should return empty array for unknown contractId', () => {
+    expect(selectLedgerEntriesByContractId(state, 'CUNKNOWN')).toEqual([])
+  })
+
+  it('should return empty array for empty string', () => {
+    expect(selectLedgerEntriesByContractId(state, '')).toEqual([])
+  })
+
+  it('should return empty array for whitespace-only string', () => {
+    expect(selectLedgerEntriesByContractId(state, '   ')).toEqual([])
+    expect(selectLedgerEntriesByContractId(state, '\t')).toEqual([])
+  })
+
+  it('should return empty array for non-string types at runtime', () => {
+    // @ts-ignore - testing runtime behavior
+    expect(selectLedgerEntriesByContractId(state, null)).toEqual([])
+    // @ts-ignore - testing runtime behavior
+    expect(selectLedgerEntriesByContractId(state, undefined)).toEqual([])
+    // @ts-ignore - testing runtime behavior
+    expect(selectLedgerEntriesByContractId(state, 123)).toEqual([])
+  })
+
+  it('should return empty array when ledgerData is empty', () => {
+    const emptyState = makeState([])
+    expect(selectLedgerEntriesByContractId(emptyState, 'CABC')).toEqual([])
+  })
+
+  it('should not match partial contractId strings', () => {
+    expect(selectLedgerEntriesByContractId(state, 'CAB')).toEqual([])
+    expect(selectLedgerEntriesByContractId(state, 'CABCD')).toEqual([])
+  })
+})


### PR DESCRIPTION
- Add new selector function to filter ledger entries by contract ID
- Implement deterministic sorting of results by entry key in ascending order
- Handle edge cases: empty strings, whitespace, non-string types, and unknown contract IDs
- Add comprehensive test suite with 9 test cases covering all scenarios
- Selector validates input and returns empty array for invalid or unknown contract IDs

closes #82 