### PR TITLE
contract between UI thread and worker

### DIFF
--- a/src/test/workers/decoder.worker.test.ts
+++ b/src/test/workers/decoder.worker.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
 import * as Comlink from 'comlink'
-import type { DecoderWorkerAPI } from '../../workers/decoder.worker'
+
+import type { DecoderWorkerApi } from '../../types/decoder-worker'
 
 // Mock Comlink.wrap to return a mock worker API
 vi.mock('comlink', () => ({
   wrap: vi.fn(() => ({
-    ping: vi.fn().mockResolvedValue('pong'),
+    ping: vi.fn().mockResolvedValue({ status: 'pong' }),
   })),
 }))
 
@@ -16,8 +17,10 @@ describe('DecoderWorker Comlink Integration', () => {
   it('should successfully call ping through Comlink and receive pong response', async () => {
     // Arrange
     const mockWorkerAPI = {
-      ping: vi.fn().mockResolvedValue('pong'),
-    } as unknown as Comlink.Remote<DecoderWorkerAPI>
+      ping: vi
+        .fn()
+        .mockResolvedValue({ status: 'pong' }),
+    } as unknown as Comlink.Remote<DecoderWorkerApi>
 
     // Mock Comlink.wrap to return our mock
     vi.mocked(Comlink.wrap).mockReturnValue(mockWorkerAPI)
@@ -26,7 +29,7 @@ describe('DecoderWorker Comlink Integration', () => {
     const result = await mockWorkerAPI.ping()
 
     // Assert
-    expect(result).toBe('pong')
+    expect(result).toEqual({ status: 'pong' })
     expect(mockWorkerAPI.ping).toHaveBeenCalledOnce()
   })
 

--- a/src/types/decoder-worker.ts
+++ b/src/types/decoder-worker.ts
@@ -1,0 +1,127 @@
+/**
+ * Typed contract between UI thread and decoder worker.
+ * Provides strong typing for all worker request/response payloads and error handling.
+ */
+
+import type {
+  NormalizedAddress,
+  NormalizedValue,
+  ScVal,
+} from '../workers/decoder/normalizeScVal'
+
+/**
+ * Typed error object for predictable error handling in worker communication.
+ * All errors returned from worker methods conform to this structure.
+ */
+export interface DecoderWorkerError {
+  /** Machine-readable error code for error classification and handling */
+  code: string
+  /** Human-readable error message */
+  message: string
+  /** Optional additional error details for debugging */
+  details?: Record<string, unknown>
+}
+
+/**
+ * Request payload for the ping method.
+ * Currently empty but structured for future extensibility.
+ */
+export interface PingRequest {
+  // Structured for potential future parameters
+}
+
+/**
+ * Response payload for the ping method.
+ */
+export interface PingResponse {
+  status: string
+}
+
+/**
+ * Request payload for normalizing an ScVal.
+ */
+export interface NormalizeRequest {
+  /** The ScVal to normalize */
+  scVal: ScVal
+  /** Optional flag to normalize as address type if applicable */
+  asAddress?: boolean
+}
+
+/**
+ * Successful response for normalize request containing normalized value.
+ */
+export interface NormalizeValueResponse {
+  type: 'value'
+  value: NormalizedValue
+}
+
+/**
+ * Successful response for normalize request containing normalized address.
+ */
+export interface NormalizeAddressResponse {
+  type: 'address'
+  value: NormalizedAddress | null
+}
+
+/**
+ * Union of possible successful normalize responses.
+ */
+export type NormalizeResponse = NormalizeValueResponse | NormalizeAddressResponse
+
+/**
+ * Result type for normalize method - either success or error.
+ */
+export type NormalizeResult = NormalizeResponse | DecoderWorkerError
+
+/**
+ * Defines the complete API contract for the decoder worker.
+ * Both the worker and main thread wrapper must implement/use these signatures.
+ */
+export interface DecoderWorkerApi {
+  /**
+   * Health check method to verify worker is responsive.
+   * @returns Promise resolving with 'pong' status
+   * @throws DecoderWorkerError with code 'PING_FAILED' if worker is unresponsive
+   */
+  ping: () => Promise<PingResponse>
+
+  /**
+   * Normalizes an ScVal (Soroban Contract Value) to a JSON-serializable format.
+   * Handles both regular values and address types with automatic detection.
+   *
+   * @param request - NormalizeRequest containing the ScVal to normalize
+   * @returns Promise resolving to NormalizeResult (success response or error)
+   * @throws Never throws; errors are returned in the NormalizeResult union
+   *
+   * @example
+   * // Normalize a regular ScVal
+   * const result = await worker.normalize({ scVal: myScVal });
+   * if ('code' in result) {
+   *   // Handle error
+   *   console.error(result.message);
+   * } else {
+   *   console.log(result.value);
+   * }
+   *
+   * @example
+   * // Normalize as address
+   * const result = await worker.normalize({
+   *   scVal: myAddressScVal,
+   *   asAddress: true
+   * });
+   */
+  normalize: (request: NormalizeRequest) => Promise<NormalizeResult>
+}
+
+/**
+ * Type guard to check if a result is a DecoderWorkerError.
+ * Useful for error handling in consuming code.
+ *
+ * @param result - The result to check
+ * @returns True if result is an error, false otherwise
+ */
+export function isDecoderWorkerError(
+  result: NormalizeResult,
+): result is DecoderWorkerError {
+  return 'code' in result
+}

--- a/src/workers/createDecoderWorker.ts
+++ b/src/workers/createDecoderWorker.ts
@@ -1,10 +1,17 @@
 import * as Comlink from 'comlink'
-import type { DecoderWorkerAPI } from './decoder.worker'
 
-export function createDecoderWorker(): Comlink.Remote<DecoderWorkerAPI> {
+import type { DecoderWorkerApi } from '../types/decoder-worker'
+
+/**
+ * Creates and returns a typed remote worker for decoder operations.
+ * The returned worker conforms to the DecoderWorkerApi contract.
+ *
+ * @returns A Comlink-wrapped remote worker typed to DecoderWorkerApi
+ */
+export function createDecoderWorker(): Comlink.Remote<DecoderWorkerApi> {
   const worker = new Worker(new URL('./decoder.worker.ts', import.meta.url), {
     type: 'module',
   })
 
-  return Comlink.wrap<DecoderWorkerAPI>(worker)
+  return Comlink.wrap<DecoderWorkerApi>(worker)
 }

--- a/src/workers/decoder.worker.ts
+++ b/src/workers/decoder.worker.ts
@@ -1,16 +1,64 @@
 import * as Comlink from 'comlink'
 
-// Define the worker API interface
-export interface DecoderWorkerAPI {
-  ping: () => Promise<string>
-}
+import {
+  normalizeScAddress,
+  normalizeScVal,
+} from './decoder/normalizeScVal'
+import type {
+  DecoderWorkerApi,
+  DecoderWorkerError,
+  NormalizeRequest,
+  NormalizeResult,
+  PingResponse,
+} from '../types/decoder-worker'
 
-// Implementation of the worker API
-const decoderWorkerAPI: DecoderWorkerAPI = {
-  ping(): Promise<string> {
-    return Promise.resolve('pong')
+/**
+ * Implements the typed decoder worker API.
+ * All methods conform to the DecoderWorkerApi contract defined in types/decoder-worker.ts
+ */
+const decoderWorkerApi: DecoderWorkerApi = {
+  ping(): Promise<PingResponse> {
+    return Promise.resolve({ status: 'pong' })
+  },
+
+  normalize(request: NormalizeRequest): Promise<NormalizeResult> {
+    try {
+      const { scVal, asAddress = false } = request
+
+      // Normalize as address if requested and applicable
+      if (asAddress) {
+        const normalizedAddress = normalizeScAddress(scVal)
+        return Promise.resolve({
+          type: 'address',
+          value: normalizedAddress,
+        })
+      }
+
+      // Default: normalize as value
+      const normalizedValue = normalizeScVal(scVal)
+      return Promise.resolve({
+        type: 'value',
+        value: normalizedValue,
+      })
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      const errorDetails: Record<string, unknown> = {}
+
+      if (error instanceof Error) {
+        errorDetails.stack = error.stack
+        errorDetails.name = error.name
+      }
+
+      const workerError: DecoderWorkerError = {
+        code: 'NORMALIZE_FAILED',
+        message: `Failed to normalize ScVal: ${errorMessage}`,
+        details: errorDetails,
+      }
+
+      return Promise.resolve(workerError)
+    }
   },
 }
 
-// Expose the API through Comlink
-Comlink.expose(decoderWorkerAPI)
+// Expose the fully typed API through Comlink
+Comlink.expose(decoderWorkerApi)


### PR DESCRIPTION
## Pr Description
A typed contract between the UI thread and worker

## Changes
- Added `src/types/decoder-worker.ts` with shared worker contracts
- Defined `DecoderWorkerApi` (`ping`, `normalize`)
- Introduced typed worker error (`code`, `message`, `details`)
- Shared types used by both worker and main-thread wrapper

---

This PR closes #18 