### PR TITLE
feat: Implement primitive decoder: bool, void, error, symbol

### DIFF
--- a/src/test/decoder/primitive.nonNumeric.test.ts
+++ b/src/test/decoder/primitive.nonNumeric.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest'
+import { ScValType, normalizeScVal } from '../../workers/decoder/normalizeScVal'
+import type {
+  NormalizedError,
+  ScVal,
+} from '../../workers/decoder/normalizeScVal'
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeScVal(switchType: ScValType, value?: unknown): ScVal {
+  return { switch: switchType, value }
+}
+
+// ---------------------------------------------------------------------------
+// Bool
+// ---------------------------------------------------------------------------
+
+describe('normalizeScVal – Bool', () => {
+  it('normalizes true to boolean true', () => {
+    const result = normalizeScVal(makeScVal(ScValType.SCV_BOOL, true))
+    expect(result).toBe(true)
+    expect(typeof result).toBe('boolean')
+  })
+
+  it('normalizes false to boolean false', () => {
+    const result = normalizeScVal(makeScVal(ScValType.SCV_BOOL, false))
+    expect(result).toBe(false)
+    expect(typeof result).toBe('boolean')
+  })
+
+  it('defaults to false when value is not a boolean', () => {
+    const invalidCases = [0, 1, 'true', null, undefined, {}, []]
+
+    invalidCases.forEach((badValue) => {
+      const result = normalizeScVal(makeScVal(ScValType.SCV_BOOL, badValue))
+      expect(result).toBe(false)
+    })
+  })
+
+  it('preserves exact fixture output shape for true', () => {
+    expect(normalizeScVal(makeScVal(ScValType.SCV_BOOL, true))).toStrictEqual(
+      true,
+    )
+  })
+
+  it('preserves exact fixture output shape for false', () => {
+    expect(normalizeScVal(makeScVal(ScValType.SCV_BOOL, false))).toStrictEqual(
+      false,
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Void
+// ---------------------------------------------------------------------------
+
+describe('normalizeScVal – Void', () => {
+  it('normalizes void with no value to null', () => {
+    const result = normalizeScVal(makeScVal(ScValType.SCV_VOID))
+    expect(result).toBe(null)
+  })
+
+  it('normalizes void with undefined value to null', () => {
+    const result = normalizeScVal(makeScVal(ScValType.SCV_VOID, undefined))
+    expect(result).toBe(null)
+  })
+
+  it('normalizes void even when an unexpected payload is present', () => {
+    // Void always produces null regardless of any stray payload
+    const result = normalizeScVal(makeScVal(ScValType.SCV_VOID, 42))
+    expect(result).toBe(null)
+  })
+
+  it('preserves exact fixture output shape', () => {
+    expect(normalizeScVal(makeScVal(ScValType.SCV_VOID))).toStrictEqual(null)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Symbol
+// ---------------------------------------------------------------------------
+
+describe('normalizeScVal – Symbol', () => {
+  const symbolFixtures = [
+    { value: 'transfer', expected: 'transfer' },
+    { value: 'mint', expected: 'mint' },
+    { value: 'burn', expected: 'burn' },
+    { value: '', expected: '' },
+    { value: 'SNAKE_CASE_SYMBOL', expected: 'SNAKE_CASE_SYMBOL' },
+    { value: 'symbol-with-dashes', expected: 'symbol-with-dashes' },
+  ]
+
+  symbolFixtures.forEach(({ value, expected }) => {
+    it(`normalizes symbol "${value}" to string "${expected}"`, () => {
+      const result = normalizeScVal(makeScVal(ScValType.SCV_SYMBOL, value))
+      expect(result).toBe(expected)
+      expect(typeof result).toBe('string')
+    })
+  })
+
+  it('defaults to empty string when value is not a string', () => {
+    const invalidCases = [42, true, null, undefined, [], {}]
+
+    invalidCases.forEach((badValue) => {
+      const result = normalizeScVal(makeScVal(ScValType.SCV_SYMBOL, badValue))
+      expect(result).toBe('')
+    })
+  })
+
+  it('preserves exact fixture output shape', () => {
+    expect(
+      normalizeScVal(makeScVal(ScValType.SCV_SYMBOL, 'transfer')),
+    ).toStrictEqual('transfer')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+describe('normalizeScVal – Error', () => {
+  describe('well-formed error value', () => {
+    const errorFixtures: Array<{
+      type: string
+      code: number
+    }> = [
+      { type: 'contract', code: 1 },
+      { type: 'wasm_vm', code: 0 },
+      { type: 'context', code: 3 },
+      { type: 'storage', code: 2 },
+      { type: 'object', code: 5 },
+      { type: 'crypto', code: 6 },
+      { type: 'events', code: 7 },
+      { type: 'budget', code: 8 },
+      { type: 'value', code: 9 },
+      { type: 'auth', code: 4 },
+    ]
+
+    errorFixtures.forEach(({ type, code }) => {
+      it(`normalizes error type="${type}" code=${code} to NormalizedError`, () => {
+        const scVal = makeScVal(ScValType.SCV_ERROR, { type, code })
+        const result = normalizeScVal(scVal) as NormalizedError
+
+        expect(result.__error).toBe(true)
+        expect(result.type).toBe(type)
+        expect(result.code).toBe(code)
+      })
+    })
+
+    it('preserves exact fixture output shape for contract error', () => {
+      const scVal = makeScVal(ScValType.SCV_ERROR, { type: 'contract', code: 1 })
+      expect(normalizeScVal(scVal)).toStrictEqual({
+        __error: true,
+        type: 'contract',
+        code: 1,
+      })
+    })
+
+    it('coerces numeric code to number', () => {
+      const scVal = makeScVal(ScValType.SCV_ERROR, { type: 'value', code: '7' })
+      const result = normalizeScVal(scVal) as NormalizedError
+
+      expect(result.__error).toBe(true)
+      expect(typeof result.code).toBe('number')
+      expect(result.code).toBe(7)
+    })
+
+    it('coerces non-string type to string', () => {
+      const scVal = makeScVal(ScValType.SCV_ERROR, { type: 99, code: 0 })
+      const result = normalizeScVal(scVal) as NormalizedError
+
+      expect(result.__error).toBe(true)
+      expect(typeof result.type).toBe('string')
+      expect(result.type).toBe('99')
+    })
+  })
+
+  describe('malformed / missing error value', () => {
+    const malformedCases = [
+      { label: 'undefined value', value: undefined },
+      { label: 'null value', value: null },
+      { label: 'string value', value: 'oops' },
+      { label: 'number value', value: 42 },
+      { label: 'missing code field', value: { type: 'contract' } },
+      { label: 'missing type field', value: { code: 1 } },
+      { label: 'empty object', value: {} },
+    ]
+
+    malformedCases.forEach(({ label, value }) => {
+      it(`returns safe default NormalizedError for ${label}`, () => {
+        const scVal = makeScVal(ScValType.SCV_ERROR, value)
+        const result = normalizeScVal(scVal) as NormalizedError
+
+        expect(result.__error).toBe(true)
+        expect(result.type).toBe('unknown')
+        expect(result.code).toBe(0)
+      })
+    })
+
+    it('default fallback is JSON-serializable', () => {
+      const scVal = makeScVal(ScValType.SCV_ERROR)
+      const result = normalizeScVal(scVal)
+
+      // Must not throw
+      const serialized = JSON.stringify(result)
+      expect(typeof serialized).toBe('string')
+      expect(JSON.parse(serialized)).toEqual({ __error: true, type: 'unknown', code: 0 })
+    })
+  })
+
+  describe('error does not crash for any input', () => {
+    it('returns a NormalizedError even for deeply unexpected values', () => {
+      const edgeCases = [
+        { type: null, code: null },
+        { type: undefined, code: undefined },
+        { type: [], code: {} },
+      ]
+
+      edgeCases.forEach((value) => {
+        const scVal = makeScVal(ScValType.SCV_ERROR, value)
+        const result = normalizeScVal(scVal) as NormalizedError
+
+        // Should always have the discriminant
+        expect(result.__error).toBe(true)
+        expect(typeof result.type).toBe('string')
+        expect(typeof result.code).toBe('number')
+      })
+    })
+  })
+})

--- a/src/types/normalized.ts
+++ b/src/types/normalized.ts
@@ -1,0 +1,96 @@
+/**
+ * Normalized value union types for Soroban State Lens
+ *
+ * This module defines the canonical output shapes produced by the decoder.
+ * All normalized decoder outputs must be expressible as one of the variants
+ * in NormalizedValue. UI rendering and serialization consume these types.
+ *
+ * Discriminant conventions:
+ *   __cycle      → CycleMarker        (cycle detected during traversal)
+ *   __error      → NormalizedError    (ScVal error variant)
+ *   __unsupported → UnsupportedFallback (unrecognised or unimplemented variant)
+ */
+
+// ---------------------------------------------------------------------------
+// CycleMarker
+// ---------------------------------------------------------------------------
+
+/**
+ * Returned in place of a value when the normalizer detects a cyclic reference.
+ */
+export interface CycleMarker {
+  __cycle: true
+  depth?: number
+}
+
+// ---------------------------------------------------------------------------
+// NormalizedError
+// ---------------------------------------------------------------------------
+
+/**
+ * Represents a normalized `ScvError` Soroban contract value.
+ *
+ * The `type` field corresponds to the ScErrorType name (e.g. "contract",
+ * "wasm_vm", "storage", …) and `code` is the raw numeric error code from
+ * ScErrorCode.
+ */
+export interface NormalizedError {
+  __error: true
+  type: string
+  code: number
+}
+
+// ---------------------------------------------------------------------------
+// UnsupportedFallback
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable, deterministic fallback returned for ScVal variants that are not yet
+ * decoded.  The object is always JSON-serializable.
+ */
+export interface UnsupportedFallback {
+  __unsupported: true
+  /** The ScVal switch name, e.g. "ScvU64". */
+  variant: string
+  /** Raw payload from the original ScVal, or null when absent. */
+  rawData: unknown
+}
+
+// ---------------------------------------------------------------------------
+// NormalizedMapEntry
+// ---------------------------------------------------------------------------
+
+/**
+ * A single key/value pair inside a normalized map.
+ * Represented as a pair rather than a plain JS object so that non-string
+ * keys (addresses, tuples, etc.) are preserved without loss.
+ */
+export interface NormalizedMapEntry {
+  key: NormalizedValue
+  value: NormalizedValue
+}
+
+// ---------------------------------------------------------------------------
+// NormalizedValue – the top-level union
+// ---------------------------------------------------------------------------
+
+/**
+ * The complete set of shapes that the decoder can emit.
+ *
+ * Primitive JS types (boolean, number, string, null) represent scalar ScVal
+ * variants that map cleanly: bool → boolean, void → null, i32/u32 → number,
+ * symbol/string → string.
+ *
+ * Structured variants (error, unsupported, cycle, map entries, nested vecs)
+ * use tagged object shapes with a unique discriminant property.
+ */
+export type NormalizedValue =
+  | boolean
+  | number
+  | string
+  | null
+  | CycleMarker
+  | NormalizedError
+  | UnsupportedFallback
+  | Array<NormalizedValue>
+  | { [key: string]: NormalizedValue }

--- a/src/types/stellar-sdk.d.ts
+++ b/src/types/stellar-sdk.d.ts
@@ -14,7 +14,7 @@ declare module '@stellar/stellar-sdk' {
   export namespace rpc {
     class Server {
       constructor(serverUrl: string, options?: any)
-      getLedgerEntries(...keys: Array<any>): Promise<GetLedgerEntriesResponse>
+      getLedgerEntries(...keys: Array<any>): Promise<Api.GetLedgerEntriesResponse>
     }
 
     namespace Api {
@@ -25,11 +25,6 @@ declare module '@stellar/stellar-sdk' {
         liveUntilLedgerSeq?: number
       }
     }
-  }
-
-  interface GetLedgerEntriesResponse {
-    entries: Array<rpc.Api.LedgerEntryResult>
-    latestLedger: number
   }
 
   export class Address {


### PR DESCRIPTION
This PR implements the primitive decoder, which are the bool, void, error and symbol.

Closes #21 