### PR TITLE
Add startLedgerHeadPoll service for ledger head polling

### DIFF
--- a/src/lib/network/ledgerPoller.ts
+++ b/src/lib/network/ledgerPoller.ts
@@ -1,0 +1,78 @@
+import { buildJsonRpcRequest } from '../rpc/buildJsonRpcRequest'
+import { toRpcRequestId } from '../rpc/toRpcRequestId'
+import { callRpc } from './rpcClient'
+import type { RpcConfig, RpcError } from './types'
+
+export interface GetLatestLedgerResult {
+  id?: string
+  protocolVersion?: number
+  sequence: number
+}
+
+export interface LedgerHeadPollOptions {
+  rpcConfig: RpcConfig
+  intervalMs?: number
+  onLedgerChange: (sequence: number) => void
+}
+
+const DEFAULT_INTERVAL_MS = 5000
+
+function isRpcError(value: unknown): value is RpcError {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'message' in value &&
+    typeof (value as RpcError).message === 'string'
+  )
+}
+
+export function startLedgerHeadPoll(
+  options: LedgerHeadPollOptions,
+): () => void {
+  const {
+    rpcConfig,
+    intervalMs = DEFAULT_INTERVAL_MS,
+    onLedgerChange,
+  } = options
+
+  let lastSequence: number | null = null
+  const stoppedRef = { current: false }
+
+  const tick = async (): Promise<void> => {
+    if (stoppedRef.current) return
+
+    const body = buildJsonRpcRequest('getLatestLedger', {}, toRpcRequestId())
+    const response = await callRpc<{ result?: GetLatestLedgerResult }>(
+      rpcConfig,
+      body,
+    )
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- stop() can run during await
+    if (stoppedRef.current) return
+    if (isRpcError(response)) return
+
+    const result = response.result
+    if (
+      result == null ||
+      typeof result !== 'object' ||
+      typeof result.sequence !== 'number'
+    ) {
+      return
+    }
+
+    const { sequence } = result
+    if (lastSequence === null || sequence > lastSequence) {
+      lastSequence = sequence
+      onLedgerChange(sequence)
+    }
+  }
+
+  const intervalId = setInterval(tick, intervalMs)
+  tick()
+
+  return function stop(): void {
+    if (stoppedRef.current) return
+    stoppedRef.current = true
+    clearInterval(intervalId)
+  }
+}

--- a/src/test/network/ledgerPoller.test.ts
+++ b/src/test/network/ledgerPoller.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { startLedgerHeadPoll } from '../../lib/network/ledgerPoller'
+import { callRpc } from '../../lib/network/rpcClient'
+
+vi.mock('../../lib/network/rpcClient', () => ({
+  callRpc: vi.fn(),
+}))
+
+const mockCallRpc = vi.mocked(callRpc)
+
+describe('startLedgerHeadPoll', () => {
+  const defaultRpcConfig = {
+    url: 'https://rpc.example.com',
+    timeout: 5000,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('emits changes only on sequence increment', () => {
+    it('calls onLedgerChange when sequence increases', async () => {
+      const onLedgerChange = vi.fn()
+      mockCallRpc
+        .mockResolvedValueOnce({ result: { sequence: 100 } })
+        .mockResolvedValueOnce({ result: { sequence: 101 } })
+        .mockResolvedValueOnce({ result: { sequence: 102 } })
+
+      const stop = startLedgerHeadPoll({
+        rpcConfig: defaultRpcConfig,
+        intervalMs: 1000,
+        onLedgerChange,
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(onLedgerChange).toHaveBeenCalledWith(100)
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(onLedgerChange).toHaveBeenCalledWith(101)
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(onLedgerChange).toHaveBeenCalledWith(102)
+      expect(onLedgerChange).toHaveBeenCalledTimes(3)
+      stop()
+    })
+
+    it('does not call onLedgerChange when sequence is unchanged', async () => {
+      const onLedgerChange = vi.fn()
+      mockCallRpc
+        .mockResolvedValueOnce({ result: { sequence: 100 } })
+        .mockResolvedValueOnce({ result: { sequence: 100 } })
+        .mockResolvedValueOnce({ result: { sequence: 100 } })
+
+      const stop = startLedgerHeadPoll({
+        rpcConfig: defaultRpcConfig,
+        intervalMs: 1000,
+        onLedgerChange,
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(onLedgerChange).toHaveBeenCalledTimes(1)
+      expect(onLedgerChange).toHaveBeenCalledWith(100)
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(onLedgerChange).toHaveBeenCalledTimes(1)
+      stop()
+    })
+
+    it('does not call onLedgerChange when sequence decreases', async () => {
+      const onLedgerChange = vi.fn()
+      mockCallRpc
+        .mockResolvedValueOnce({ result: { sequence: 102 } })
+        .mockResolvedValueOnce({ result: { sequence: 101 } })
+        .mockResolvedValueOnce({ result: { sequence: 100 } })
+
+      const stop = startLedgerHeadPoll({
+        rpcConfig: defaultRpcConfig,
+        intervalMs: 1000,
+        onLedgerChange,
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(onLedgerChange).toHaveBeenCalledWith(102)
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(onLedgerChange).toHaveBeenCalledTimes(1)
+      stop()
+    })
+
+    it('calls onLedgerChange only for first poll when result has no sequence then valid sequence', async () => {
+      const onLedgerChange = vi.fn()
+      mockCallRpc
+        .mockResolvedValueOnce({ result: {} })
+        .mockResolvedValueOnce({ result: { sequence: 100 } })
+
+      const stop = startLedgerHeadPoll({
+        rpcConfig: defaultRpcConfig,
+        intervalMs: 1000,
+        onLedgerChange,
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(onLedgerChange).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(onLedgerChange).toHaveBeenCalledTimes(1)
+      expect(onLedgerChange).toHaveBeenCalledWith(100)
+      stop()
+    })
+
+    it('does not call onLedgerChange when RPC returns error', async () => {
+      const onLedgerChange = vi.fn()
+      mockCallRpc.mockResolvedValue({ message: 'Network error', code: 'NETWORK_ERROR' })
+
+      const stop = startLedgerHeadPoll({
+        rpcConfig: defaultRpcConfig,
+        intervalMs: 1000,
+        onLedgerChange,
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(onLedgerChange).not.toHaveBeenCalled()
+      stop()
+    })
+  })
+
+  describe('stop function', () => {
+    it('halts further polling and callbacks after stop', async () => {
+      const onLedgerChange = vi.fn()
+      mockCallRpc
+        .mockResolvedValueOnce({ result: { sequence: 100 } })
+        .mockResolvedValueOnce({ result: { sequence: 101 } })
+        .mockResolvedValueOnce({ result: { sequence: 102 } })
+
+      const stop = startLedgerHeadPoll({
+        rpcConfig: defaultRpcConfig,
+        intervalMs: 1000,
+        onLedgerChange,
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(mockCallRpc).toHaveBeenCalledTimes(3)
+      expect(onLedgerChange).toHaveBeenCalledTimes(3)
+
+      stop()
+
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(mockCallRpc).toHaveBeenCalledTimes(3)
+      expect(onLedgerChange).toHaveBeenCalledTimes(3)
+    })
+
+    it('stop is idempotent', async () => {
+      mockCallRpc.mockResolvedValue({ result: { sequence: 100 } })
+      const stop = startLedgerHeadPoll({
+        rpcConfig: defaultRpcConfig,
+        intervalMs: 1000,
+        onLedgerChange: vi.fn(),
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+      stop()
+      stop()
+      stop()
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(mockCallRpc).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('configurable options', () => {
+    it('uses default interval 5000ms when intervalMs omitted', async () => {
+      mockCallRpc.mockResolvedValue({ result: { sequence: 1 } })
+      const onLedgerChange = vi.fn()
+
+      startLedgerHeadPoll({
+        rpcConfig: defaultRpcConfig,
+        onLedgerChange,
+      })
+
+      expect(mockCallRpc).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(4999)
+      expect(mockCallRpc).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(mockCallRpc).toHaveBeenCalledTimes(2)
+    })
+
+    it('uses custom interval when intervalMs provided', async () => {
+      mockCallRpc.mockResolvedValue({ result: { sequence: 1 } })
+
+      startLedgerHeadPoll({
+        rpcConfig: defaultRpcConfig,
+        intervalMs: 2000,
+        onLedgerChange: vi.fn(),
+      })
+
+      expect(mockCallRpc).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(1999)
+      expect(mockCallRpc).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(mockCallRpc).toHaveBeenCalledTimes(2)
+    })
+
+    it('passes rpcConfig to callRpc', async () => {
+      const config = {
+        url: 'https://custom.rpc.url',
+        timeout: 10000,
+        headers: { 'X-Custom': 'value' },
+      }
+      mockCallRpc.mockResolvedValue({ result: { sequence: 1 } })
+
+      const stop = startLedgerHeadPoll({
+        rpcConfig: config,
+        intervalMs: 10000,
+        onLedgerChange: vi.fn(),
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(mockCallRpc).toHaveBeenCalledWith(
+        config,
+        expect.objectContaining({
+          jsonrpc: '2.0',
+          method: 'getLatestLedger',
+        }),
+      )
+      stop()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Adds a ledger head poll service so the app only reacts when the ledger sequence advances, avoiding unnecessary updates when the sequence is unchanged.

## Changes
- **`src/lib/network/ledgerPoller.ts`** – New `startLedgerHeadPoll(options)` that:
  - Polls `getLatestLedger` via `rpcClient.callRpc` on a configurable interval (default 5000ms).
  - Invokes `onLedgerChange` only when the reported sequence is greater than the previous one.
  - Returns a `stop()` function that clears the interval and prevents further polling and callbacks.
- **`src/test/network/ledgerPoller.test.ts`** – Tests for sequence-only emissions, stop behavior, and configurable options.

## Acceptance criteria
- [x] Poller emits changes only on sequence increment.
- [x] Stop function stops further polling and callbacks.
- [x] Interval and callbacks are configurable via typed options (`LedgerHeadPollOptions`).

## Verification
`bun run lint` · `bun run build` · `bun run test` (all pass).

Closes #29 