### PR TITLE
Add a UTF-8 preview helper for bytes

### DIFF
--- a/src/lib/format/bytesToHex.ts
+++ b/src/lib/format/bytesToHex.ts
@@ -24,6 +24,44 @@ export function bytesToHex(bytes: Uint8Array | null | undefined): string {
 }
 
 /**
+ * Decodes bytes as UTF-8 when the sequence is valid.
+ * Returns an empty string for empty input and null for invalid or unreadable UTF-8.
+ */
+export function bytesToUtf8Preview(
+  bytes: Uint8Array | null | undefined,
+): string | null {
+  if (!bytes || bytes.length === 0) {
+    return ''
+  }
+
+  try {
+    const text = new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+    return isReadableUtf8Preview(text) ? text : null
+  } catch {
+    return null
+  }
+}
+
+function isReadableUtf8Preview(text: string): boolean {
+  for (const character of text) {
+    const codePoint = character.codePointAt(0)
+    if (codePoint === undefined) {
+      return false
+    }
+
+    if (codePoint === 0x09 || codePoint === 0x0a || codePoint === 0x0d) {
+      continue
+    }
+
+    if (codePoint < 0x20 || (codePoint >= 0x7f && codePoint <= 0x9f)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
  * Type guard to check if a value is a Uint8Array.
  */
 export function isUint8Array(value: unknown): value is Uint8Array {

--- a/src/test/decoder/primitive.bytes.test.ts
+++ b/src/test/decoder/primitive.bytes.test.ts
@@ -14,6 +14,7 @@ describe('ScVal Bytes Normalization', () => {
       kind: 'primitive',
       primitive: 'bytes',
       value: '0x',
+      preview: '',
     })
   })
 
@@ -28,6 +29,7 @@ describe('ScVal Bytes Normalization', () => {
       kind: 'primitive',
       primitive: 'bytes',
       value: '0x0102030405',
+      preview: null,
     })
   })
 
@@ -46,6 +48,7 @@ describe('ScVal Bytes Normalization', () => {
       kind: 'primitive',
       primitive: 'bytes',
       value: '0x0123456789abcdeffedcba9876543210',
+      preview: null,
     })
   })
 
@@ -60,6 +63,40 @@ describe('ScVal Bytes Normalization', () => {
       kind: 'primitive',
       primitive: 'bytes',
       value: '0x0000ff80',
+      preview: null,
+    })
+  })
+
+  test('should include readable UTF-8 preview when bytes decode safely', () => {
+    const scVal: ScVal = {
+      switch: ScValType.SCV_BYTES,
+      value: new Uint8Array([
+        72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 33,
+      ]),
+    }
+    const result = normalizeScVal(scVal)
+
+    expect(result).toEqual({
+      kind: 'primitive',
+      primitive: 'bytes',
+      value: '0x48656c6c6f2c20776f726c6421',
+      preview: 'Hello, world!',
+    })
+  })
+
+  test('should return null preview for invalid utf-8 byte sequences', () => {
+    const scVal: ScVal = {
+      switch: ScValType.SCV_BYTES,
+      value: new Uint8Array([0xc3, 0x28]),
+    }
+
+    const result = normalizeScVal(scVal)
+
+    expect(result).toEqual({
+      kind: 'primitive',
+      primitive: 'bytes',
+      value: '0xc328',
+      preview: null,
     })
   })
 
@@ -76,6 +113,7 @@ describe('ScVal Bytes Normalization', () => {
       kind: 'primitive',
       primitive: 'bytes',
       value: '0x',
+      preview: null,
     })
   })
 })

--- a/src/test/format/bytesToHex.test.ts
+++ b/src/test/format/bytesToHex.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'vitest'
-import { bytesToHex, isUint8Array } from '../../lib/format/bytesToHex'
+import {
+  bytesToHex,
+  bytesToUtf8Preview,
+  isUint8Array,
+} from '../../lib/format/bytesToHex'
 
 describe('bytesToHex', () => {
   test('should return "0x" for null input', () => {
@@ -45,6 +49,23 @@ describe('bytesToHex', () => {
   test('should handle mixed values', () => {
     const mixedBytes = new Uint8Array([0, 1, 15, 16, 255, 128])
     expect(bytesToHex(mixedBytes)).toBe('0x00010f10ff80')
+  })
+})
+
+describe('bytesToUtf8Preview', () => {
+  test('should return empty string for empty byte array', () => {
+    const emptyBytes = new Uint8Array([])
+    expect(bytesToUtf8Preview(emptyBytes)).toBe('')
+  })
+
+  test('should decode valid UTF-8 text', () => {
+    const textBytes = new TextEncoder().encode('Hello, Soroban!')
+    expect(bytesToUtf8Preview(textBytes)).toBe('Hello, Soroban!')
+  })
+
+  test('should return null for invalid UTF-8 byte sequences', () => {
+    const invalidBytes = new Uint8Array([0xc3, 0x28])
+    expect(bytesToUtf8Preview(invalidBytes)).toBe(null)
   })
 })
 

--- a/src/types/normalized.ts
+++ b/src/types/normalized.ts
@@ -126,6 +126,7 @@ export interface NormalizedPrimitive {
   kind: 'primitive'
   primitive: PrimitiveKind
   value: boolean | number | string | null
+  preview?: string | null
 }
 
 export interface NormalizedVec {

--- a/src/workers/decoder/normalizeScVal.ts
+++ b/src/workers/decoder/normalizeScVal.ts
@@ -1,5 +1,9 @@
 import { Address, xdr } from '@stellar/stellar-sdk'
-import { bytesToHex, isUint8Array } from '../../lib/format/bytesToHex'
+import {
+  bytesToHex,
+  bytesToUtf8Preview,
+  isUint8Array,
+} from '../../lib/format/bytesToHex'
 import { VisitedTracker, createVisitedTracker } from './guards'
 import type {
   CycleMarker,
@@ -361,6 +365,9 @@ export function normalizeScVal(
         kind: 'primitive',
         primitive: 'bytes',
         value: isUint8Array(scVal.value) ? bytesToHex(scVal.value) : '0x',
+        preview: isUint8Array(scVal.value)
+          ? bytesToUtf8Preview(scVal.value)
+          : null,
       }
 
     case ScValType.SCV_ERROR: {


### PR DESCRIPTION
- This change adds a safe UTF-8 preview helper for byte payloads. 
- It returns readable text only when decoding succeeds and the result is actually readable, returns an empty string for empty input, and returns null for invalid or unreadable UTF-8 sequences. 
- The bytes normalization path now includes the preview, and tests cover valid text bytes, empty bytes, and invalid UTF-8 sequences.

closes #169 