### PR TITLE
feat: implement withRpcRetries utility with exponential backoff and j…

### DIFF
--- a/src/lib/rpc/withRpcRetries.ts
+++ b/src/lib/rpc/withRpcRetries.ts
@@ -86,7 +86,7 @@ export async function withRpcRetries<T>(
 
   let attempt = 1
 
-  while (true) {
+  for (;;) {
     let result: T | undefined
     let errorObj: unknown = null
     let didThrow = false

--- a/src/lib/rpc/withRpcRetries.ts
+++ b/src/lib/rpc/withRpcRetries.ts
@@ -1,0 +1,125 @@
+import { shouldRetryRpcError } from './shouldRetryRpcError'
+import { computeRetryDelayMs } from './computeRetryDelayMs'
+import { withJitter } from './withJitter'
+import { isJsonRpcErrorResponse } from './isJsonRpcErrorResponse'
+
+export interface RpcRetryOptions {
+  maxAttempts?: number
+  baseDelayMs?: number
+  maxDelayMs?: number
+  jitterRatio?: number
+}
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+function isRpcClientError(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+  const candidate = value as Record<string, unknown>
+
+  // Exclude valid JSON-RPC success responses to be safe
+  if ('jsonrpc' in candidate && 'result' in candidate) {
+    return false
+  }
+
+  const hasMessageString = typeof candidate.message === 'string'
+  const hasCodeOrTimeout = 'code' in candidate || 'isTimeout' in candidate
+
+  return hasMessageString && hasCodeOrTimeout
+}
+
+function shouldRetry(errorObj: unknown): boolean {
+  let status: number | undefined
+  let code: string | number | undefined
+
+  if (isJsonRpcErrorResponse(errorObj)) {
+    code = errorObj.error.code
+  } else if (typeof errorObj === 'object' && errorObj !== null) {
+    const candidate = errorObj as Record<string, unknown>
+    if (typeof candidate.status === 'number') {
+      status = candidate.status
+    }
+
+    if (candidate.code !== undefined) {
+      if (
+        typeof candidate.code === 'number' &&
+        candidate.code >= 100 &&
+        candidate.code <= 599 &&
+        status === undefined
+      ) {
+        // rpcClient uses `code` for HTTP status for non-200 responses
+        status = candidate.code
+      } else {
+        code = candidate.code as string | number
+      }
+    }
+  }
+
+  // Check native error object
+  if (errorObj instanceof Error) {
+    const errCode = (errorObj as any).code
+    if (code === undefined && errCode !== undefined) {
+      code = errCode
+    }
+  }
+
+  return shouldRetryRpcError({ status, code })
+}
+
+/**
+ * A reusable wrapper that executes an asynchronous operation and applies
+ * bounded exponential backoff for transient RPC or Network failures.
+ *
+ * @param operation The function to execute. Can throw or return an error object.
+ * @param options Configurations for retry limits and backoff timing.
+ * @returns The successful result, or the final failure if retries are exhausted.
+ */
+export async function withRpcRetries<T>(
+  operation: () => Promise<T>,
+  options: RpcRetryOptions = {},
+): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? 3
+  const baseDelayMs = options.baseDelayMs ?? 250
+  const maxDelayMs = options.maxDelayMs ?? 5000
+  const jitterRatio = options.jitterRatio ?? 0.2
+
+  let attempt = 1
+
+  while (true) {
+    let result: T | undefined
+    let errorObj: unknown = null
+    let didThrow = false
+
+    try {
+      result = await operation()
+
+      // Determine if a successful promise resolution is conceptually an error
+      if (isJsonRpcErrorResponse(result)) {
+        errorObj = result
+      } else if (isRpcClientError(result)) {
+        errorObj = result
+      }
+    } catch (err) {
+      didThrow = true
+      errorObj = err
+    }
+
+    if (!errorObj) {
+      return result as T
+    }
+
+    if (attempt >= maxAttempts || !shouldRetry(errorObj)) {
+      if (didThrow) {
+        throw errorObj
+      }
+      return result as T
+    }
+
+    const delayMs = computeRetryDelayMs(attempt - 1, baseDelayMs, maxDelayMs)
+    const jitteredMs = withJitter(delayMs, jitterRatio)
+    await delay(jitteredMs)
+
+    attempt++
+  }
+}

--- a/src/test/rpc/withRpcRetries.test.ts
+++ b/src/test/rpc/withRpcRetries.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest'
+import { withRpcRetries } from '../../lib/rpc/withRpcRetries'
+
+describe('withRpcRetries', () => {
+  it('should return result if operation succeeds immediately', async () => {
+    const fn = vi.fn().mockResolvedValue('success')
+    const result = await withRpcRetries(fn)
+    expect(result).toBe('success')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should retry a retryable thrown error and succeed', async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce({ code: 'TIMEOUT', message: 'timeout' })
+      .mockResolvedValueOnce('success')
+
+    const result = await withRpcRetries(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      jitterRatio: 0,
+    })
+    expect(result).toBe('success')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('should surface the final failure clearly when retries are exhausted (thrown error)', async () => {
+    const errorObj = { code: 'NETWORK_ERROR', message: 'Fail' }
+    const fn = vi.fn().mockRejectedValue(errorObj)
+
+    await expect(
+      withRpcRetries(fn, { maxAttempts: 3, baseDelayMs: 1, jitterRatio: 0 })
+    ).rejects.toEqual(errorObj)
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it('should fail immediately on a non-retryable failure (thrown error)', async () => {
+    const errorObj = { code: 400, message: 'Bad request' }
+    const fn = vi.fn().mockRejectedValue(errorObj)
+
+    await expect(
+      withRpcRetries(fn, { maxAttempts: 3, baseDelayMs: 1, jitterRatio: 0 })
+    ).rejects.toEqual(errorObj)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should retry a retryable returned JSON-RPC error response', async () => {
+    const rpcError = {
+      jsonrpc: '2.0',
+      id: 1,
+      error: { code: -32603, message: 'Internal error' },
+    }
+    const fn = vi.fn()
+      .mockResolvedValueOnce(rpcError)
+      .mockResolvedValueOnce('success')
+
+    const result = await withRpcRetries(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      jitterRatio: 0,
+    })
+    expect(result).toBe('success')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('should return the final JSON-RPC error if retries are exhausted', async () => {
+    const rpcError = {
+      jsonrpc: '2.0',
+      id: 1,
+      error: { code: -32603, message: 'Internal error' },
+    }
+    const fn = vi.fn().mockResolvedValue(rpcError)
+
+    const result = await withRpcRetries(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      jitterRatio: 0,
+    })
+    expect(result).toEqual(rpcError)
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it('should retry a retryable returned Network RpcError (e.g. 429)', async () => {
+    const networkError = { message: 'HTTP 429', code: 429, isTimeout: false }
+    const fn = vi.fn()
+      .mockResolvedValueOnce(networkError)
+      .mockResolvedValueOnce('success')
+
+    const result = await withRpcRetries(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      jitterRatio: 0,
+    })
+    expect(result).toBe('success')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('should not retry a non-retryable returned Network RpcError (e.g. 400)', async () => {
+    const networkError = { message: 'HTTP 400', code: 400, isTimeout: false }
+    const fn = vi.fn().mockResolvedValue(networkError)
+
+    const result = await withRpcRetries(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      jitterRatio: 0,
+    })
+    expect(result).toEqual(networkError)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should treat Network Timeout RpcError as retryable', async () => {
+    const networkError = { message: 'Timeout', code: 'TIMEOUT', isTimeout: true }
+    const fn = vi.fn()
+      .mockResolvedValueOnce(networkError)
+      .mockResolvedValueOnce('success')
+
+    const result = await withRpcRetries(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      jitterRatio: 0,
+    })
+    expect(result).toBe('success')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
This PR introduces the withRpcRetries implementation, establishing a single, predictable retry policy for executing network operations.

Centralized Wrapper: Adds withRpcRetries, which accepts an executing closure and manages geometric backoff with jitter natively.
Targeted Surface Area: Identifies both exception-style try/catch throws, standard internal RpcError network responses, and generic JSON-RPC .error payloads.
Strictly Transient Handling: Delegates retry decisions to our existing shouldRetryRpcError so that only transient problems (429s and 5xx) are retried. Completely fatal client issues (400, 403, etc.) bypass retries entirely.
Includes thorough testing for exhaustions, successes after a retry, and non-retryable bypass paths as outlined in the acceptance criteria.


closes #219