### PR TITLE
feat: Add settings network route with RPC configuration summary

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SdsDemoRouteImport } from './routes/sds-demo'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as SettingsNetworkRouteImport } from './routes/settings/network'
 import { Route as ContractsContractIdIndexRouteImport } from './routes/contracts/$contractId/index'
 import { Route as ContractsContractIdExplorerRouteImport } from './routes/contracts/$contractId/explorer'
 
@@ -22,6 +23,11 @@ const SdsDemoRoute = SdsDemoRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SettingsNetworkRoute = SettingsNetworkRouteImport.update({
+  id: '/settings/network',
+  path: '/settings/network',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ContractsContractIdIndexRoute =
@@ -40,12 +46,14 @@ const ContractsContractIdExplorerRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/sds-demo': typeof SdsDemoRoute
+  '/settings/network': typeof SettingsNetworkRoute
   '/contracts/$contractId/explorer': typeof ContractsContractIdExplorerRoute
   '/contracts/$contractId/': typeof ContractsContractIdIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/sds-demo': typeof SdsDemoRoute
+  '/settings/network': typeof SettingsNetworkRoute
   '/contracts/$contractId/explorer': typeof ContractsContractIdExplorerRoute
   '/contracts/$contractId': typeof ContractsContractIdIndexRoute
 }
@@ -53,6 +61,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/sds-demo': typeof SdsDemoRoute
+  '/settings/network': typeof SettingsNetworkRoute
   '/contracts/$contractId/explorer': typeof ContractsContractIdExplorerRoute
   '/contracts/$contractId/': typeof ContractsContractIdIndexRoute
 }
@@ -61,18 +70,21 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/sds-demo'
+    | '/settings/network'
     | '/contracts/$contractId/explorer'
     | '/contracts/$contractId/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/sds-demo'
+    | '/settings/network'
     | '/contracts/$contractId/explorer'
     | '/contracts/$contractId'
   id:
     | '__root__'
     | '/'
     | '/sds-demo'
+    | '/settings/network'
     | '/contracts/$contractId/explorer'
     | '/contracts/$contractId/'
   fileRoutesById: FileRoutesById
@@ -80,6 +92,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   SdsDemoRoute: typeof SdsDemoRoute
+  SettingsNetworkRoute: typeof SettingsNetworkRoute
   ContractsContractIdExplorerRoute: typeof ContractsContractIdExplorerRoute
   ContractsContractIdIndexRoute: typeof ContractsContractIdIndexRoute
 }
@@ -98,6 +111,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/network': {
+      id: '/settings/network'
+      path: '/settings/network'
+      fullPath: '/settings/network'
+      preLoaderRoute: typeof SettingsNetworkRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/contracts/$contractId/': {
@@ -120,6 +140,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   SdsDemoRoute: SdsDemoRoute,
+  SettingsNetworkRoute: SettingsNetworkRoute,
   ContractsContractIdExplorerRoute: ContractsContractIdExplorerRoute,
   ContractsContractIdIndexRoute: ContractsContractIdIndexRoute,
 }

--- a/src/routes/settings/network.tsx
+++ b/src/routes/settings/network.tsx
@@ -1,0 +1,158 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useNetworkConfig, useLensStore } from '../../store/lensStore'
+import { ConnectionStatus } from '../../store/types'
+import { DEFAULT_NETWORKS } from '../../store/lensStore'
+
+export const Route = createFileRoute('/settings/network')({
+  component: SettingsNetwork,
+})
+
+function SettingsNetwork() {
+  const networkConfig = useNetworkConfig()
+  const connectionStatus = useLensStore((state) => state.connectionStatus)
+  const lastCustomUrl = useLensStore((state) => state.lastCustomUrl)
+
+  const isCustomNetwork = !Object.values(DEFAULT_NETWORKS).some(
+    (network) => network.rpcUrl === networkConfig.rpcUrl
+  )
+
+  const getConnectionStatusColor = (status: ConnectionStatus) => {
+    switch (status) {
+      case ConnectionStatus.SUCCESS:
+        return 'text-green-500'
+      case ConnectionStatus.ERROR:
+        return 'text-red-500'
+      case ConnectionStatus.LOADING:
+        return 'text-yellow-500'
+      default:
+        return 'text-gray-500'
+    }
+  }
+
+  const getConnectionStatusText = (status: ConnectionStatus) => {
+    switch (status) {
+      case ConnectionStatus.SUCCESS:
+        return 'Connected'
+      case ConnectionStatus.ERROR:
+        return 'Connection Failed'
+      case ConnectionStatus.LOADING:
+        return 'Connecting...'
+      default:
+        return 'Not Connected'
+    }
+  }
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-white mb-2">Network Settings</h1>
+        <p className="text-gray-400">
+          View and manage your network configuration settings
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        {/* Current Network Configuration */}
+        <div className="bg-gray-800 rounded-lg p-6">
+          <h2 className="text-lg font-semibold text-white mb-4">
+            Current Network Configuration
+          </h2>
+          
+          <div className="space-y-4">
+            {/* Network Type */}
+            <div className="flex justify-between items-center py-3 border-b border-gray-700">
+              <span className="text-gray-300">Network Type</span>
+              <span className="text-white font-medium">
+                {isCustomNetwork ? 'Custom RPC' : 'Preset Network'}
+              </span>
+            </div>
+
+            {/* Network ID */}
+            <div className="flex justify-between items-center py-3 border-b border-gray-700">
+              <span className="text-gray-300">Network ID</span>
+              <span className="text-white font-medium">{networkConfig.networkId}</span>
+            </div>
+
+            {/* RPC URL */}
+            <div className="flex justify-between items-center py-3 border-b border-gray-700">
+              <span className="text-gray-300">RPC URL</span>
+              <span className="text-white font-mono text-sm">{networkConfig.rpcUrl}</span>
+            </div>
+
+            {/* Horizon URL (if available) */}
+            {networkConfig.horizonUrl && (
+              <div className="flex justify-between items-center py-3 border-b border-gray-700">
+                <span className="text-gray-300">Horizon URL</span>
+                <span className="text-white font-mono text-sm">{networkConfig.horizonUrl}</span>
+              </div>
+            )}
+
+            {/* Network Passphrase */}
+            <div className="flex justify-between items-start py-3 border-b border-gray-700">
+              <span className="text-gray-300">Network Passphrase</span>
+              <span className="text-white font-mono text-sm text-right max-w-md break-all">
+                {networkConfig.networkPassphrase}
+              </span>
+            </div>
+
+            {/* Connection Status */}
+            <div className="flex justify-between items-center py-3">
+              <span className="text-gray-300">Connection Status</span>
+              <span className={`font-medium ${getConnectionStatusColor(connectionStatus)}`}>
+                {getConnectionStatusText(connectionStatus)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Last Custom URL (if available) */}
+        {lastCustomUrl && (
+          <div className="bg-gray-800 rounded-lg p-6">
+            <h2 className="text-lg font-semibold text-white mb-4">
+              Last Custom RPC URL
+            </h2>
+            <div className="flex justify-between items-center py-3">
+              <span className="text-gray-300">URL</span>
+              <span className="text-white font-mono text-sm">{lastCustomUrl}</span>
+            </div>
+          </div>
+        )}
+
+        {/* Available Preset Networks */}
+        <div className="bg-gray-800 rounded-lg p-6">
+          <h2 className="text-lg font-semibold text-white mb-4">
+            Available Preset Networks
+          </h2>
+          <div className="space-y-3">
+            {Object.entries(DEFAULT_NETWORKS).map(([key, network]) => (
+              <div
+                key={key}
+                className={`p-3 rounded border ${
+                  network.rpcUrl === networkConfig.rpcUrl
+                    ? 'bg-blue-900 border-blue-500'
+                    : 'bg-gray-700 border-gray-600'
+                }`}
+              >
+                <div className="flex justify-between items-center">
+                  <div>
+                    <div className="text-white font-medium capitalize">
+                      {key}
+                    </div>
+                    <div className="text-gray-400 text-sm">
+                      {network.rpcUrl}
+                    </div>
+                  </div>
+                  {network.rpcUrl === networkConfig.rpcUrl && (
+                    <span className="text-blue-400 text-sm font-medium">
+                      Active
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/routes/settings/network.tsx
+++ b/src/routes/settings/network.tsx
@@ -1,7 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { useNetworkConfig, useLensStore } from '../../store/lensStore'
+import {
+  DEFAULT_NETWORKS,
+  useLensStore,
+  useNetworkConfig,
+} from '../../store/lensStore'
 import { ConnectionStatus } from '../../store/types'
-import { DEFAULT_NETWORKS } from '../../store/lensStore'
 
 export const Route = createFileRoute('/settings/network')({
   component: SettingsNetwork,


### PR DESCRIPTION
## Summary
- Add /settings/network route to display network configuration
- Render current preset and custom RPC configuration summary
- Show connection status and network details
- Display available preset networks with active indicator
- Implement persistent network state reading from store

## Changes
- Created new route component at [src/routes/settings/network.tsx](cci:7://file:///C:/Users/EDDIE%20PC/CascadeProjects/Soroban-state-lens/src/routes/settings/network.tsx:0:0-0:0)
- Updated route tree to include the new settings network route
- Integrated with existing Zustand store for state management

## Acceptance Criteria
- ✅ Visiting settings/network shows the current saved network config in a dedicated route
- ✅ The summary reflects current stored settings after refresh

## Issue Reference
Fixes: Scaffold the settings network route with a saved RPC summary

## Labels
enhancement, help wanted, good first issue, phase:7, area:ui, size:s, difficulty:beginner


CLOSES  #217 