### PR TITLE
feat: add contract load lifecycle and explorer loading states

### DIFF
--- a/src/lib/network/mapLedgerEntriesToStoreEntries.ts
+++ b/src/lib/network/mapLedgerEntriesToStoreEntries.ts
@@ -1,0 +1,31 @@
+import { makeLedgerEntryKey } from '../storage/makeLedgerEntryKey'
+import type { LedgerEntry as RpcLedgerEntry } from './getLedgerEntries'
+import type { LedgerEntry as StoreLedgerEntry } from '../../store/types'
+
+interface MapLedgerEntriesParams {
+  contractId: string
+  entries: Array<RpcLedgerEntry>
+  decodedValuesByKey?: Record<string, unknown>
+}
+
+/**
+ * Maps raw RPC ledger-entry payloads into the canonical store entry shape.
+ */
+export function mapLedgerEntriesToStoreEntries(
+  params: MapLedgerEntriesParams,
+): Array<StoreLedgerEntry> {
+  const { contractId, entries, decodedValuesByKey = {} } = params
+
+  return entries.map((entry) => ({
+    key: makeLedgerEntryKey(contractId, 'Other', entry.key),
+    contractId,
+    type: 'Other',
+    value:
+      decodedValuesByKey[entry.key] !== undefined
+        ? decodedValuesByKey[entry.key]
+        : entry.xdr,
+    lastModifiedLedger: entry.lastModifiedLedgerSeq ?? 0,
+    expirationLedger: entry.liveUntilLedgerSeq,
+    rawXdr: entry.xdr,
+  }))
+}

--- a/src/routes/contracts/$contractId/explorer.tsx
+++ b/src/routes/contracts/$contractId/explorer.tsx
@@ -1,13 +1,19 @@
+import { useEffect, useMemo } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { Button, Card, Heading } from '@stellar/design-system'
+import { selectLedgerEntriesByContractId } from '../../../lib/selectors/selectLedgerEntriesByContractId'
+import { ContractLoadStatus } from '../../../store/types'
+import { useLensStore } from '../../../store/lensStore'
 import { validateContractRouteParam } from './-validateContractRouteParam'
 
 export const Route = createFileRoute('/contracts/$contractId/explorer')({
   component: ContractExplorer,
+  validateSearch: (search: Record<string, unknown>) => ({
+    keys: typeof search.keys === 'string' ? search.keys : '',
+  }),
   beforeLoad: ({ params }) => {
     const result = validateContractRouteParam(params.contractId)
     if (!result.ok) {
-      // For now just log or we could throw a redirect
       console.error(`Invalid contract ID: ${result.reason}`)
     }
     return {
@@ -19,18 +25,66 @@ export const Route = createFileRoute('/contracts/$contractId/explorer')({
 function ContractExplorer() {
   const { contractId } = Route.useParams()
   const { normalizedContractId } = Route.useRouteContext()
+  const search = Route.useSearch()
+
+  const setActiveContractId = useLensStore((state) => state.setActiveContractId)
+  const setContractLoadStatus = useLensStore(
+    (state) => state.setContractLoadStatus,
+  )
+  const setContractLoadError = useLensStore((state) => state.setContractLoadError)
+  const loadContract = useLensStore((state) => state.loadContract)
+  const contractLoadStatus = useLensStore((state) => state.contractLoadStatus)
+  const contractLoadError = useLensStore((state) => state.contractLoadError)
+
+  const ledgerEntries = useLensStore((state) =>
+    selectLedgerEntriesByContractId(state, contractId),
+  )
+
+  const keys = useMemo(
+    () =>
+      search.keys
+        .split(',')
+        .map((key) => key.trim())
+        .filter((key) => key.length > 0),
+    [search.keys],
+  )
+
+  useEffect(() => {
+    setActiveContractId(contractId)
+
+    if (keys.length === 0) {
+      setContractLoadError(null)
+      setContractLoadStatus(ContractLoadStatus.EMPTY)
+      return
+    }
+
+    void loadContract(contractId, keys)
+  }, [
+    contractId,
+    keys,
+    loadContract,
+    setActiveContractId,
+    setContractLoadError,
+    setContractLoadStatus,
+  ])
+
+  const handleRetry = () => {
+    if (keys.length === 0) {
+      setContractLoadError(null)
+      setContractLoadStatus(ContractLoadStatus.EMPTY)
+      return
+    }
+
+    void loadContract(contractId, keys)
+  }
 
   return (
     <div className="flex flex-col gap-6 p-6 lg:p-10 max-w-6xl mx-auto w-full">
-      {/* Contract Header/Shell */}
       <header className="flex flex-col md:flex-row md:items-end justify-between gap-4 border-b border-border-dark pb-6">
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-3">
             <span className="px-2 py-0.5 rounded bg-primary/20 text-primary text-[10px] font-bold uppercase tracking-wider font-mono">
               Contract
-            </span>
-            <span className="text-text-muted font-mono text-sm hidden sm:inline">
-              v1.0.0
             </span>
           </div>
           <Heading size="lg" as="h1" className="font-mono break-all text-white">
@@ -39,54 +93,13 @@ function ContractExplorer() {
         </div>
 
         <div className="flex items-center gap-3 shrink-0">
-          <div className="flex flex-col items-end gap-1">
-            <span className="text-[10px] font-bold uppercase tracking-widest text-text-muted">
-              Status
-            </span>
-            <div className="flex items-center gap-2 text-green-400 font-mono text-sm bg-green-400/10 px-2 py-1 rounded border border-green-400/20">
-              <span className="size-2 bg-green-400 rounded-full animate-pulse" />
-              Active
-            </div>
-          </div>
+          <Button variant="secondary" size="sm" onClick={handleRetry}>
+            Retry Load
+          </Button>
         </div>
       </header>
 
-      {/* Placeholder Content */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <Card>
-          <div className="p-6 space-y-6">
-            <div className="space-y-2">
-              <Heading
-                size="sm"
-                as="h3"
-                className="text-text-muted uppercase tracking-widest text-[11px] font-bold"
-              >
-                Contract Overview
-              </Heading>
-              <p className="text-text-secondary leading-relaxed">
-                This contract is currently being indexed. The explorer view will
-                soon provide a detailed breakdown of ledger entries, events, and
-                source code for this address.
-              </p>
-            </div>
-
-            <div className="pt-4 border-t border-border-dark flex items-center gap-4">
-              <div className="flex flex-col gap-1">
-                <span className="text-[10px] font-bold uppercase tracking-widest text-text-muted">
-                  Last Updated
-                </span>
-                <span className="text-white font-mono text-sm">Just now</span>
-              </div>
-              <div className="flex flex-col gap-1">
-                <span className="text-[10px] font-bold uppercase tracking-widest text-text-muted">
-                  Network
-                </span>
-                <span className="text-white font-mono text-sm">Testnet</span>
-              </div>
-            </div>
-          </div>
-        </Card>
-
+      {contractLoadStatus === ContractLoadStatus.LOADING && (
         <Card>
           <div className="p-6 space-y-4">
             <Heading
@@ -94,50 +107,84 @@ function ContractExplorer() {
               as="h3"
               className="text-text-muted uppercase tracking-widest text-[11px] font-bold"
             >
-              Quick Actions
+              Loading State
             </Heading>
-            <div className="flex flex-col gap-2">
-              <Button
-                variant="secondary"
-                size="md"
-                className="w-full justify-start text-sm"
-              >
-                View on Stellar.Expert
-              </Button>
-              <Button
-                variant="secondary"
-                size="md"
-                className="w-full justify-start text-sm"
-              >
-                Copy Contract ID
-              </Button>
-              <Button
-                variant="secondary"
-                size="md"
-                className="w-full justify-start text-sm"
-              >
-                Download WASM
+            <div className="space-y-3">
+              {Array.from({ length: 6 }).map((_, idx) => (
+                <div
+                  key={idx}
+                  className="h-10 rounded bg-white/5 border border-border-dark animate-pulse"
+                />
+              ))}
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {contractLoadStatus === ContractLoadStatus.EMPTY && (
+        <Card>
+          <div className="p-6 space-y-3">
+            <Heading size="sm" as="h3" className="text-white">
+              No Contract Data Found
+            </Heading>
+            <p className="text-text-muted text-sm">
+              The current contract query completed, but no ledger entries were
+              returned.
+            </p>
+            {keys.length === 0 && (
+              <p className="text-text-muted text-xs">
+                Add one or more base64 ledger keys via `?keys=...` to load
+                entries in this route.
+              </p>
+            )}
+          </div>
+        </Card>
+      )}
+
+      {contractLoadStatus === ContractLoadStatus.ERROR && (
+        <Card>
+          <div className="p-6 space-y-4 border border-red-500/20 bg-red-500/5 rounded-xl">
+            <Heading size="sm" as="h3" className="text-red-300">
+              Failed To Load Contract Data
+            </Heading>
+            <p className="text-text-muted text-sm">
+              {contractLoadError || 'An unknown error occurred while loading.'}
+            </p>
+            <div>
+              <Button variant="secondary" size="sm" onClick={handleRetry}>
+                Retry
               </Button>
             </div>
           </div>
         </Card>
-      </div>
+      )}
 
-      {/* Secondary Placeholder */}
-      <div className="mt-4 border border-dashed border-border-dark rounded-xl p-12 flex flex-col items-center justify-center text-center gap-4 bg-surface-dark/20">
-        <div className="size-12 bg-white/5 rounded-full flex items-center justify-center text-text-muted">
-          <span className="material-symbols-outlined text-3xl">database</span>
-        </div>
-        <div className="max-w-md space-y-2">
-          <Heading size="sm" as="h4" className="text-white">
-            State Explorer Coming Soon
-          </Heading>
-          <p className="text-text-muted text-sm">
-            We're building a powerful way to visualize and interact with this
-            contract's state directly from your browser. Stay tuned!
-          </p>
-        </div>
-      </div>
+      {contractLoadStatus === ContractLoadStatus.SUCCESS && (
+        <Card>
+          <div className="p-6 space-y-4">
+            <Heading
+              size="sm"
+              as="h3"
+              className="text-text-muted uppercase tracking-widest text-[11px] font-bold"
+            >
+              Loaded Entries ({ledgerEntries.length})
+            </Heading>
+
+            <div className="space-y-2">
+              {ledgerEntries.map((entry) => (
+                <div
+                  key={entry.key}
+                  className="rounded border border-border-dark bg-surface-dark/30 p-3"
+                >
+                  <div className="font-mono text-xs text-white break-all">
+                    {entry.key}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </Card>
+      )}
     </div>
   )
 }

--- a/src/store/lensStore.ts
+++ b/src/store/lensStore.ts
@@ -1,7 +1,17 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
-import { BigIntDisplayMode, ByteDisplayMode, ConnectionStatus, DEFAULT_NETWORKS  } from './types'
+import { getLedgerEntries } from '../lib/network/getLedgerEntries'
+import { mapLedgerEntriesToStoreEntries } from '../lib/network/mapLedgerEntriesToStoreEntries'
+import { isDecoderWorkerError } from '../types/decoder-worker'
+import { createDecoderWorkerSafe } from '../workers/createDecoderWorkerSafe'
+import {
+  BigIntDisplayMode,
+  ByteDisplayMode,
+  ConnectionStatus,
+  ContractLoadStatus,
+  DEFAULT_NETWORKS,
+} from './types'
 import {
   DEFAULT_NETWORK_CONFIG,
   NETWORK_CONFIG_STORAGE_KEY,
@@ -14,6 +24,7 @@ import { createPreferencesSlice } from './preferencesSlice'
 
 import type { PersistedState } from './persistence'
 import type {
+  ContractLoadSlice,
   ExpandedNodesSlice,
   LedgerDataSlice,
   LedgerEntry,
@@ -215,6 +226,108 @@ const createSnapshotSlice = (
 })
 
 /**
+ * Contract-load slice creator
+ * Manages load lifecycle and guards against stale in-flight requests.
+ */
+const createContractLoadSlice = (
+  set: (fn: (state: LensStore) => Partial<LensStore>) => void,
+  get: () => LensStore,
+): ContractLoadSlice => {
+  let requestId = 0
+  let activeController: AbortController | null = null
+
+  return {
+    contractLoadStatus: ContractLoadStatus.IDLE,
+    contractLoadError: null,
+
+    setContractLoadStatus: (status: ContractLoadStatus) =>
+      set(() => ({ contractLoadStatus: status })),
+
+    setContractLoadError: (message: string | null) =>
+      set(() => ({ contractLoadError: message })),
+
+    resetContractLoadState: () =>
+      set(() => ({
+        contractLoadStatus: ContractLoadStatus.IDLE,
+        contractLoadError: null,
+      })),
+
+    loadContract: async (contractId: string, keys: Array<string>) => {
+      requestId += 1
+      const currentRequestId = requestId
+
+      if (activeController) {
+        activeController.abort()
+      }
+
+      activeController = new AbortController()
+      const signal = activeController.signal
+
+      set((state) => ({
+        activeContractId: contractId,
+        contractLoadStatus: ContractLoadStatus.LOADING,
+        contractLoadError: null,
+        ledgerData:
+          state.activeContractId === contractId ? state.ledgerData : {},
+      }))
+
+      try {
+        const { entries } = await getLedgerEntries({
+          rpcUrl: get().networkConfig.rpcUrl,
+          keys,
+          signal,
+        })
+
+        if (currentRequestId !== requestId || signal.aborted) {
+          return
+        }
+
+        const worker = await createDecoderWorkerSafe()
+        const decodedValuesByKey: Record<string, unknown> = {}
+
+        for (const entry of entries) {
+          const result = await worker.decodeScVal({ xdr: entry.xdr })
+          decodedValuesByKey[entry.key] = isDecoderWorkerError(result)
+            ? entry.xdr
+            : result
+        }
+
+        const mappedEntries = mapLedgerEntriesToStoreEntries({
+          contractId,
+          entries,
+          decodedValuesByKey,
+        })
+
+        set(() => ({
+          ledgerData: Object.fromEntries(
+            mappedEntries.map((entry) => [entry.key, entry]),
+          ),
+          contractLoadStatus:
+            mappedEntries.length === 0
+              ? ContractLoadStatus.EMPTY
+              : ContractLoadStatus.SUCCESS,
+          contractLoadError: null,
+        }))
+      } catch (error) {
+        if (currentRequestId !== requestId || signal.aborted) {
+          return
+        }
+
+        set(() => ({
+          contractLoadStatus: ContractLoadStatus.ERROR,
+          contractLoadError:
+            error instanceof Error ? error.message : 'Failed to load contract',
+        }))
+      } finally {
+        if (activeController.signal === signal) {
+          activeController = null
+        }
+      }
+    },
+  }
+}
+
+/**
  * Watchlist slice creator
  * Manages pinned keys for quick access across routes
  */
@@ -278,6 +391,7 @@ const createWatchlistSlice = (
  * - networkConfig: Current network configuration (PERSISTED)
  * - ledgerData: Cached ledger entries (NOT persisted)
  * - expandedNodes: Tree view expansion state (NOT persisted)
+ * - contractLoadStatus: Contract fetch lifecycle (NOT persisted)
  * - watchlist: Pinned keys for quick access (NOT persisted)
  */
 export const useLensStore = create<LensStore>()(
@@ -289,6 +403,7 @@ export const useLensStore = create<LensStore>()(
       ...createSnapshotSlice(set, get),
       ...createWatchlistSlice(set, get),
       ...createContractSlice(set),
+      ...createContractLoadSlice(set, get),
       ...createPreferencesSlice(set),
     }),
     {
@@ -319,6 +434,12 @@ export const useNetworkConfig = () =>
 export const useLedgerData = () => useLensStore((state) => state.ledgerData)
 export const useExpandedNodes = () =>
   useLensStore((state) => state.expandedNodes)
+export const useActiveContractId = () =>
+  useLensStore((state) => state.activeContractId)
+export const useContractLoadStatus = () =>
+  useLensStore((state) => state.contractLoadStatus)
+export const useContractLoadError = () =>
+  useLensStore((state) => state.contractLoadError)
 export const useSnapshots = (contractId: string) =>
   useLensStore((state) => state.snapshots[contractId] ?? [])
 export const useWatchlist = (contractId: string) =>
@@ -341,6 +462,8 @@ export const resetStore = () => {
     snapshots: {},
     watchlist: {},
     activeContractId: null,
+    contractLoadStatus: ContractLoadStatus.IDLE,
+    contractLoadError: null,
     byteDisplayMode: ByteDisplayMode.HEX,
     bigIntDisplayMode: BigIntDisplayMode.RAW,
   })
@@ -373,4 +496,14 @@ export const lensActions = {
     useLensStore.getState().getWatchlistForContract(contractId),
   clearWatchlist: (contractId: string) =>
     useLensStore.getState().clearWatchlist(contractId),
+  setActiveContractId: (contractId: string) =>
+    useLensStore.getState().setActiveContractId(contractId),
+  clearActiveContractId: () => useLensStore.getState().clearActiveContractId(),
+  setContractLoadStatus: (status: ContractLoadStatus) =>
+    useLensStore.getState().setContractLoadStatus(status),
+  setContractLoadError: (message: string | null) =>
+    useLensStore.getState().setContractLoadError(message),
+  resetContractLoadState: () => useLensStore.getState().resetContractLoadState(),
+  loadContract: (contractId: string, keys: Array<string>) =>
+    useLensStore.getState().loadContract(contractId, keys),
 }

--- a/src/store/lensStore.ts
+++ b/src/store/lensStore.ts
@@ -260,8 +260,9 @@ const createContractLoadSlice = (
         activeController.abort()
       }
 
-      activeController = new AbortController()
-      const signal = activeController.signal
+      const controller = new AbortController()
+      activeController = controller
+      const { signal } = controller
 
       set((state) => ({
         activeContractId: contractId,
@@ -319,7 +320,7 @@ const createContractLoadSlice = (
             error instanceof Error ? error.message : 'Failed to load contract',
         }))
       } finally {
-        if (activeController.signal === signal) {
+        if (activeController === controller) {
           activeController = null
         }
       }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -113,6 +113,23 @@ export interface ContractSlice {
   clearActiveContractId: () => void
 }
 
+export enum ContractLoadStatus {
+  IDLE = 'idle',
+  LOADING = 'loading',
+  SUCCESS = 'success',
+  EMPTY = 'empty',
+  ERROR = 'error',
+}
+
+export interface ContractLoadSlice {
+  contractLoadStatus: ContractLoadStatus
+  contractLoadError: string | null
+  setContractLoadStatus: (status: ContractLoadStatus) => void
+  setContractLoadError: (message: string | null) => void
+  resetContractLoadState: () => void
+  loadContract: (contractId: string, keys: Array<string>) => Promise<void>
+}
+
 // Watchlist item (pinned key for quick access)
 export interface WatchlistItem {
   contractId: string
@@ -146,6 +163,7 @@ export interface LensStore
     ExpandedNodesSlice,
     SnapshotSlice,
     ContractSlice,
+    ContractLoadSlice,
     PreferencesSlice,
     WatchlistSlice {}
 

--- a/src/test/network/mapLedgerEntriesToStoreEntries.test.ts
+++ b/src/test/network/mapLedgerEntriesToStoreEntries.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { mapLedgerEntriesToStoreEntries } from '../../lib/network/mapLedgerEntriesToStoreEntries'
+
+describe('mapLedgerEntriesToStoreEntries', () => {
+  it('maps representative entries into stable store records', () => {
+    const result = mapLedgerEntriesToStoreEntries({
+      contractId: 'CONTRACT_1',
+      entries: [
+        {
+          key: 'ledger-key-1',
+          xdr: 'xdr-1',
+          lastModifiedLedgerSeq: 42,
+          liveUntilLedgerSeq: 99,
+        },
+      ],
+      decodedValuesByKey: {
+        'ledger-key-1': { kind: 'primitive', scType: 'string', value: 'hello' },
+      },
+    })
+
+    expect(result).toEqual([
+      {
+        key: 'CONTRACT_1:Other:ledger-key-1',
+        contractId: 'CONTRACT_1',
+        type: 'Other',
+        value: { kind: 'primitive', scType: 'string', value: 'hello' },
+        lastModifiedLedger: 42,
+        expirationLedger: 99,
+        rawXdr: 'xdr-1',
+      },
+    ])
+  })
+
+  it('falls back safely when optional metadata is missing', () => {
+    const result = mapLedgerEntriesToStoreEntries({
+      contractId: 'CONTRACT_2',
+      entries: [{ key: 'ledger-key-2', xdr: 'xdr-2' }],
+    })
+
+    expect(result).toEqual([
+      {
+        key: 'CONTRACT_2:Other:ledger-key-2',
+        contractId: 'CONTRACT_2',
+        type: 'Other',
+        value: 'xdr-2',
+        lastModifiedLedger: 0,
+        expirationLedger: undefined,
+        rawXdr: 'xdr-2',
+      },
+    ])
+  })
+
+  it('maps multiple entries deterministically', () => {
+    const result = mapLedgerEntriesToStoreEntries({
+      contractId: 'CONTRACT_3',
+      entries: [
+        { key: 'a', xdr: 'xdr-a', lastModifiedLedgerSeq: 1 },
+        { key: 'b', xdr: 'xdr-b', lastModifiedLedgerSeq: 2 },
+      ],
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0]?.key).toBe('CONTRACT_3:Other:a')
+    expect(result[1]?.key).toBe('CONTRACT_3:Other:b')
+  })
+})

--- a/src/test/network/mapLedgerEntriesToStoreEntries.test.ts
+++ b/src/test/network/mapLedgerEntriesToStoreEntries.test.ts
@@ -20,7 +20,7 @@ describe('mapLedgerEntriesToStoreEntries', () => {
 
     expect(result).toEqual([
       {
-        key: 'CONTRACT_1:Other:ledger-key-1',
+        key: 'CONTRACT_1::Other::ledger-key-1',
         contractId: 'CONTRACT_1',
         type: 'Other',
         value: { kind: 'primitive', scType: 'string', value: 'hello' },
@@ -39,7 +39,7 @@ describe('mapLedgerEntriesToStoreEntries', () => {
 
     expect(result).toEqual([
       {
-        key: 'CONTRACT_2:Other:ledger-key-2',
+        key: 'CONTRACT_2::Other::ledger-key-2',
         contractId: 'CONTRACT_2',
         type: 'Other',
         value: 'xdr-2',
@@ -60,7 +60,7 @@ describe('mapLedgerEntriesToStoreEntries', () => {
     })
 
     expect(result).toHaveLength(2)
-    expect(result[0]?.key).toBe('CONTRACT_3:Other:a')
-    expect(result[1]?.key).toBe('CONTRACT_3:Other:b')
+    expect(result[0]?.key).toBe('CONTRACT_3::Other::a')
+    expect(result[1]?.key).toBe('CONTRACT_3::Other::b')
   })
 })

--- a/src/test/store/contractLoadStatus.test.ts
+++ b/src/test/store/contractLoadStatus.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getStoreState, resetStore, useLensStore } from '../../store/lensStore'
+import { ContractLoadStatus } from '../../store/types'
+
+describe('contractLoadStatus', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
+  it('initializes with idle status and null error', () => {
+    const state = getStoreState()
+    expect(state.contractLoadStatus).toBe(ContractLoadStatus.IDLE)
+    expect(state.contractLoadError).toBeNull()
+  })
+
+  it('setContractLoadStatus updates status explicitly', () => {
+    const { setContractLoadStatus } = useLensStore.getState()
+
+    setContractLoadStatus(ContractLoadStatus.LOADING)
+    expect(getStoreState().contractLoadStatus).toBe(ContractLoadStatus.LOADING)
+
+    setContractLoadStatus(ContractLoadStatus.SUCCESS)
+    expect(getStoreState().contractLoadStatus).toBe(ContractLoadStatus.SUCCESS)
+
+    setContractLoadStatus(ContractLoadStatus.EMPTY)
+    expect(getStoreState().contractLoadStatus).toBe(ContractLoadStatus.EMPTY)
+
+    setContractLoadStatus(ContractLoadStatus.ERROR)
+    expect(getStoreState().contractLoadStatus).toBe(ContractLoadStatus.ERROR)
+  })
+
+  it('setContractLoadError and resetContractLoadState behave correctly', () => {
+    const { setContractLoadStatus, setContractLoadError, resetContractLoadState } =
+      useLensStore.getState()
+
+    setContractLoadStatus(ContractLoadStatus.ERROR)
+    setContractLoadError('boom')
+
+    expect(getStoreState().contractLoadStatus).toBe(ContractLoadStatus.ERROR)
+    expect(getStoreState().contractLoadError).toBe('boom')
+
+    resetContractLoadState()
+
+    expect(getStoreState().contractLoadStatus).toBe(ContractLoadStatus.IDLE)
+    expect(getStoreState().contractLoadError).toBeNull()
+  })
+
+  it('status transitions do not mutate activeContractId or ledgerData', () => {
+    const {
+      setActiveContractId,
+      upsertLedgerEntry,
+      setContractLoadStatus,
+      setContractLoadError,
+    } = useLensStore.getState()
+
+    setActiveContractId('CABC')
+    upsertLedgerEntry({
+      key: 'CABC:Other:key-1',
+      contractId: 'CABC',
+      type: 'Other',
+      value: 'xdr',
+      lastModifiedLedger: 1,
+    })
+
+    const activeBefore = getStoreState().activeContractId
+    const dataBefore = getStoreState().ledgerData
+
+    setContractLoadStatus(ContractLoadStatus.LOADING)
+    setContractLoadError(null)
+    setContractLoadStatus(ContractLoadStatus.SUCCESS)
+
+    expect(getStoreState().activeContractId).toBe(activeBefore)
+    expect(getStoreState().ledgerData).toEqual(dataBefore)
+  })
+})

--- a/src/test/store/loadContractAction.test.ts
+++ b/src/test/store/loadContractAction.test.ts
@@ -56,7 +56,7 @@ describe('loadContract action', () => {
     expect(state.activeContractId).toBe('C1')
     expect(state.contractLoadStatus).toBe(ContractLoadStatus.SUCCESS)
     expect(Object.keys(state.ledgerData)).toHaveLength(1)
-    expect(state.ledgerData['C1:Other:key-1'].rawXdr).toBe('xdr-1')
+    expect(state.ledgerData['C1::Other::key-1'].rawXdr).toBe('xdr-1')
   })
 
   it('sets EMPTY when the load succeeds with no entries', async () => {
@@ -156,7 +156,7 @@ describe('loadContract action', () => {
 
     const state = getStoreState()
     expect(state.contractLoadStatus).toBe(ContractLoadStatus.SUCCESS)
-    expect(state.ledgerData['C_STALE:Other:new-key'].rawXdr).toBe('new-xdr')
-    expect(state.ledgerData['C_STALE:Other:old-key']).toBeUndefined()
+    expect(state.ledgerData['C_STALE::Other::new-key'].rawXdr).toBe('new-xdr')
+    expect(state.ledgerData['C_STALE::Other::old-key']).toBeUndefined()
   })
 })

--- a/src/test/store/loadContractAction.test.ts
+++ b/src/test/store/loadContractAction.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ContractLoadStatus } from '../../store/types'
+
+const mockGetLedgerEntries = vi.fn()
+const mockDecodeScVal = vi.fn()
+const mockCreateDecoderWorkerSafe = vi.fn(() =>
+  Promise.resolve({
+    decodeScVal: mockDecodeScVal,
+  }),
+)
+
+vi.mock('../../lib/network/getLedgerEntries', () => ({
+  getLedgerEntries: mockGetLedgerEntries,
+}))
+
+vi.mock('../../workers/createDecoderWorkerSafe', () => ({
+  createDecoderWorkerSafe: mockCreateDecoderWorkerSafe,
+}))
+
+describe('loadContract action', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockGetLedgerEntries.mockReset()
+    mockDecodeScVal.mockReset()
+    mockCreateDecoderWorkerSafe.mockClear()
+  })
+
+  it('loads, decodes, and stores entries on success', async () => {
+    const { resetStore, getStoreState, useLensStore } = await import(
+      '../../store/lensStore'
+    )
+    resetStore()
+
+    mockGetLedgerEntries.mockResolvedValue({
+      entries: [
+        {
+          key: 'key-1',
+          xdr: 'xdr-1',
+          lastModifiedLedgerSeq: 7,
+        },
+      ],
+      latestLedger: 100,
+    })
+
+    mockDecodeScVal.mockResolvedValue({
+      kind: 'primitive',
+      path: [],
+      scType: 'string',
+      value: 'decoded',
+      raw: { switch: 'ScvString', value: 'decoded' },
+    })
+
+    await useLensStore.getState().loadContract('C1', ['rpc-key-1'])
+
+    const state = getStoreState()
+    expect(state.activeContractId).toBe('C1')
+    expect(state.contractLoadStatus).toBe(ContractLoadStatus.SUCCESS)
+    expect(Object.keys(state.ledgerData)).toHaveLength(1)
+    expect(state.ledgerData['C1:Other:key-1'].rawXdr).toBe('xdr-1')
+  })
+
+  it('sets EMPTY when the load succeeds with no entries', async () => {
+    const { resetStore, getStoreState, useLensStore } = await import(
+      '../../store/lensStore'
+    )
+    resetStore()
+
+    mockGetLedgerEntries.mockResolvedValue({
+      entries: [],
+      latestLedger: 100,
+    })
+    mockDecodeScVal.mockResolvedValue({
+      kind: 'primitive',
+      path: [],
+      scType: 'void',
+      value: null,
+      raw: { switch: 'ScvVoid' },
+    })
+
+    await useLensStore.getState().loadContract('C_EMPTY', ['rpc-key-empty'])
+
+    const state = getStoreState()
+    expect(state.contractLoadStatus).toBe(ContractLoadStatus.EMPTY)
+    expect(state.contractLoadError).toBeNull()
+  })
+
+  it('sets ERROR when load fails', async () => {
+    const { resetStore, getStoreState, useLensStore } = await import(
+      '../../store/lensStore'
+    )
+    resetStore()
+
+    mockGetLedgerEntries.mockRejectedValue(new Error('network failure'))
+
+    await useLensStore.getState().loadContract('C_FAIL', ['rpc-key-fail'])
+
+    const state = getStoreState()
+    expect(state.contractLoadStatus).toBe(ContractLoadStatus.ERROR)
+    expect(state.contractLoadError).toBe('network failure')
+  })
+
+  it('ignores stale in-flight results and keeps newest response', async () => {
+    const { resetStore, getStoreState, useLensStore } = await import(
+      '../../store/lensStore'
+    )
+    resetStore()
+
+    let resolveFirst:
+      | ((
+          value: {
+            entries: Array<{
+              key: string
+              xdr: string
+              lastModifiedLedgerSeq?: number
+            }>
+            latestLedger: number
+          },
+        ) => void)
+      | undefined
+    const firstPromise = new Promise<{
+      entries: Array<{ key: string; xdr: string; lastModifiedLedgerSeq?: number }>
+      latestLedger: number
+    }>((resolve) => {
+      resolveFirst = resolve
+    })
+
+    mockGetLedgerEntries
+      .mockReturnValueOnce(firstPromise)
+      .mockResolvedValueOnce({
+        entries: [
+          { key: 'new-key', xdr: 'new-xdr', lastModifiedLedgerSeq: 2 },
+        ],
+        latestLedger: 2,
+      })
+
+    mockDecodeScVal.mockResolvedValue({
+      kind: 'primitive',
+      path: [],
+      scType: 'string',
+      value: 'decoded',
+      raw: { switch: 'ScvString', value: 'decoded' },
+    })
+
+    const firstCall = useLensStore.getState().loadContract('C_STALE', ['k1'])
+    const secondCall = useLensStore.getState().loadContract('C_STALE', ['k2'])
+
+    await secondCall
+
+    if (resolveFirst) {
+      resolveFirst({
+        entries: [{ key: 'old-key', xdr: 'old-xdr', lastModifiedLedgerSeq: 1 }],
+        latestLedger: 1,
+      })
+    }
+    await firstCall
+
+    const state = getStoreState()
+    expect(state.contractLoadStatus).toBe(ContractLoadStatus.SUCCESS)
+    expect(state.ledgerData['C_STALE:Other:new-key'].rawXdr).toBe('new-xdr')
+    expect(state.ledgerData['C_STALE:Other:old-key']).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- add contract load lifecycle state and actions
- add raw-ledger to store-entry mapper with tests
- wire explorer loading/empty/error/success states with retry

## Testing
- npx eslint src/store/types.ts src/store/lensStore.ts src/lib/network/mapLedgerEntriesToStoreEntries.ts src/routes/contracts/$contractId/explorer.tsx src/test/network/mapLedgerEntriesToStoreEntries.test.ts src/test/store/contractLoadStatus.test.ts src/test/store/loadContractAction.test.ts
- bun run build

Closes #176
Closes #177
Closes #178
Closes #179
Closes #180
Closes #181
Closes #182