### PR TITLE
feat: add explorer row rendering and inspect route activation

### DIFF
--- a/src/components/explorer/InspectShell.tsx
+++ b/src/components/explorer/InspectShell.tsx
@@ -1,0 +1,127 @@
+import { Button, Card, Heading, IconButton } from '@stellar/design-system'
+import { useLensStore } from '../../store/lensStore'
+
+interface InspectShellProps {
+  contractId: string
+  normalizedContractId: string
+  keyPath: string
+}
+
+interface KeyMetadata {
+  durability?: string
+  lastModifiedLedger: number
+  expirationLedger?: number
+}
+
+export function InspectShell({
+  contractId,
+  normalizedContractId,
+  keyPath,
+}: InspectShellProps) {
+  const addToWatchlist = useLensStore((state) => state.addToWatchlist)
+
+  const metadata: KeyMetadata = {
+    durability: 'Persistent',
+    lastModifiedLedger: 1234567,
+    expirationLedger: 1235000,
+  }
+
+  const handlePinKey = () => {
+    if (keyPath) {
+      addToWatchlist(contractId, keyPath)
+    }
+  }
+
+  const handleCopyXDR = () => {
+    const mockXDR = 'AAAAEgAAAAEAAAABAAAABQAAADEAA...'
+    navigator.clipboard.writeText(mockXDR)
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6 lg:p-10 max-w-6xl mx-auto w-full">
+      <header className="flex flex-col md:flex-row md:items-end justify-between gap-4 border-b border-border-dark pb-6">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-3">
+            <span className="px-2 py-0.5 rounded bg-primary/20 text-primary text-[10px] font-bold uppercase tracking-wider font-mono">
+              Inspector
+            </span>
+          </div>
+          <Heading size="lg" as="h1" className="font-mono break-all text-white">
+            {normalizedContractId || contractId}
+          </Heading>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <IconButton
+            icon="pin"
+            altText="Add to watchlist"
+            onClick={handlePinKey}
+            disabled={!keyPath}
+            aria-label="Add to watchlist"
+          />
+        </div>
+      </header>
+
+      <div className="flex items-center gap-2 text-sm text-text-muted font-mono">
+        <span>Contract</span>
+        <span>/</span>
+        <span className="text-white truncate">{keyPath || 'No key selected'}</span>
+      </div>
+
+      <Card>
+        <div className="p-6 space-y-4">
+          <Heading
+            size="sm"
+            as="h3"
+            className="text-text-muted uppercase tracking-widest text-[11px] font-bold"
+          >
+            Metadata
+          </Heading>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <div className="text-[10px] font-bold uppercase tracking-widest text-text-muted mb-1">
+                Durability
+              </div>
+              <div className="text-white font-mono">{metadata.durability}</div>
+            </div>
+            <div>
+              <div className="text-[10px] font-bold uppercase tracking-widest text-text-muted mb-1">
+                Last Modified Ledger
+              </div>
+              <div className="text-white font-mono">{metadata.lastModifiedLedger}</div>
+            </div>
+            <div>
+              <div className="text-[10px] font-bold uppercase tracking-widest text-text-muted mb-1">
+                Expiration Ledger
+              </div>
+              <div className="text-white font-mono">
+                {metadata.expirationLedger ?? 'N/A'}
+              </div>
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="p-6 space-y-4">
+          <div className="flex items-center justify-between gap-4">
+            <Heading
+              size="sm"
+              as="h3"
+              className="text-text-muted uppercase tracking-widest text-[11px] font-bold"
+            >
+              Raw XDR
+            </Heading>
+            <Button variant="secondary" size="sm" onClick={handleCopyXDR}>
+              Copy
+            </Button>
+          </div>
+          <div className="bg-surface-dark rounded p-3 max-h-48 overflow-auto">
+            <code className="text-xs text-text-secondary font-mono break-words">
+              AAAAEgAAAAEAAAABAAAABQAAADEAA...
+            </code>
+          </div>
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/src/components/explorer/TreeRow.tsx
+++ b/src/components/explorer/TreeRow.tsx
@@ -1,0 +1,100 @@
+import type { FlatTreeRow } from '../../lib/tree/flatTreeRow'
+
+interface TreeRowProps {
+  row: FlatTreeRow
+  isExpanded: boolean
+  isSelected: boolean
+  rowHeight: number
+  onToggleExpand?: (rowId: string) => void
+  onActivate?: (row: FlatTreeRow) => void
+}
+
+function formatPreview(row: FlatTreeRow): string {
+  switch (row.node.kind) {
+    case 'primitive':
+      return String(row.node.value)
+    case 'address':
+      return row.node.value
+    case 'error':
+      return `${row.node.errorType}:${row.node.code}`
+    case 'map':
+      return `${row.node.entries.length} entries`
+    case 'vec':
+      return `${row.node.items.length} items`
+    case 'unsupported':
+      return row.node.variant
+    case 'truncated':
+      return `depth=${row.node.depth}`
+    case 'cycle':
+      return `depth=${row.node.depth}`
+    default:
+      return ''
+  }
+}
+
+function typeBadge(row: FlatTreeRow): string {
+  if (row.node.kind === 'primitive') {
+    return row.node.scType
+  }
+
+  if (row.node.kind === 'address') {
+    return `address:${row.node.addressType}`
+  }
+
+  return row.kind
+}
+
+export function TreeRow({
+  row,
+  isExpanded,
+  isSelected,
+  rowHeight,
+  onToggleExpand,
+  onActivate,
+}: TreeRowProps) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      data-testid="tree-row"
+      onClick={() => onActivate?.(row)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onActivate?.(row)
+        }
+      }}
+      className={`w-full flex items-center gap-2 px-3 border-b border-white/5 text-left ${
+        isSelected ? 'bg-primary/10' : 'hover:bg-white/5'
+      }`}
+      style={{ height: rowHeight }}
+      aria-label={`Open ${row.label}`}
+    >
+      <div style={{ marginLeft: row.depth * 16 }} className="flex items-center gap-2 min-w-0">
+        {row.hasChildren ? (
+          <button
+            type="button"
+            className="text-xs text-text-muted hover:text-white"
+            onClick={(event) => {
+              event.stopPropagation()
+              onToggleExpand?.(row.id)
+            }}
+            aria-label={`Toggle ${row.label}`}
+          >
+            {isExpanded ? '▼' : '▶'}
+          </button>
+        ) : (
+          <span className="w-4" aria-hidden="true" />
+        )}
+
+        <span className="font-mono text-xs text-white truncate">{row.label}</span>
+        <span className="font-mono text-[10px] uppercase text-primary border border-primary/30 rounded px-1 py-0.5">
+          {typeBadge(row)}
+        </span>
+        <span className="font-mono text-[11px] text-text-muted truncate">
+          {formatPreview(row)}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/explorer/VirtualizedTreeList.tsx
+++ b/src/components/explorer/VirtualizedTreeList.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { TreeRow } from './TreeRow'
 import type { UIEvent } from 'react'
 import type { FlatTreeRow } from '../../lib/tree/flatTreeRow'
 
@@ -9,6 +10,8 @@ interface VirtualizedTreeListProps {
   overscan?: number
   onToggleExpand?: (rowId: string) => void
   expandedNodeIds?: ReadonlySet<string> | ReadonlyArray<string>
+  selectedRowId?: string | null
+  onActivateRow?: (row: FlatTreeRow) => void
 }
 
 export function VirtualizedTreeList({
@@ -18,6 +21,8 @@ export function VirtualizedTreeList({
   overscan = 4,
   onToggleExpand,
   expandedNodeIds = [],
+  selectedRowId,
+  onActivateRow,
 }: VirtualizedTreeListProps) {
   const [scrollTop, setScrollTop] = useState(0)
 
@@ -63,26 +68,16 @@ export function VirtualizedTreeList({
                 left: 0,
                 right: 0,
               }}
-              className="flex items-center gap-2 px-3 border-b border-white/5"
+              className="left-0 right-0"
             >
-              <div style={{ marginLeft: row.depth * 16 }} className="flex items-center gap-2">
-                {row.hasChildren ? (
-                  <button
-                    type="button"
-                    className="text-xs text-text-muted hover:text-white"
-                    onClick={() => onToggleExpand?.(row.id)}
-                    aria-label={`Toggle ${row.label}`}
-                  >
-                    {isExpanded ? '▼' : '▶'}
-                  </button>
-                ) : (
-                  <span className="w-4" />
-                )}
-                <span className="font-mono text-xs text-white">{row.label}</span>
-                <span className="font-mono text-[10px] uppercase text-text-muted">
-                  {row.kind}
-                </span>
-              </div>
+              <TreeRow
+                row={row}
+                rowHeight={rowHeight}
+                isExpanded={isExpanded}
+                isSelected={selectedRowId === row.id}
+                onToggleExpand={onToggleExpand}
+                onActivate={onActivateRow}
+              />
             </div>
           )
         })}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as ContractsContractIdIndexRouteImport } from './routes/contracts
 import { Route as ContractsContractIdInspectRouteImport } from './routes/contracts/$contractId/inspect'
 import { Route as ContractsContractIdExplorerRouteImport } from './routes/contracts/$contractId/explorer'
 import { Route as ContractsContractIdDiscoveryRouteImport } from './routes/contracts/$contractId/discovery'
+import { Route as ContractsContractIdInspectIndexRouteImport } from './routes/contracts/$contractId/inspect.index'
 import { Route as ContractsContractIdInspectKeyPathRouteImport } from './routes/contracts/$contractId/inspect.$keyPath'
 
 const SdsDemoRoute = SdsDemoRouteImport.update({
@@ -63,6 +64,12 @@ const ContractsContractIdDiscoveryRoute =
     path: '/contracts/$contractId/discovery',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ContractsContractIdInspectIndexRoute =
+  ContractsContractIdInspectIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => ContractsContractIdInspectRoute,
+  } as any)
 const ContractsContractIdInspectKeyPathRoute =
   ContractsContractIdInspectKeyPathRouteImport.update({
     id: '/$keyPath',
@@ -80,6 +87,7 @@ export interface FileRoutesByFullPath {
   '/contracts/$contractId/inspect': typeof ContractsContractIdInspectRouteWithChildren
   '/contracts/$contractId/': typeof ContractsContractIdIndexRoute
   '/contracts/$contractId/inspect/$keyPath': typeof ContractsContractIdInspectKeyPathRoute
+  '/contracts/$contractId/inspect/': typeof ContractsContractIdInspectIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -88,9 +96,9 @@ export interface FileRoutesByTo {
   '/settings/preferences': typeof SettingsPreferencesRoute
   '/contracts/$contractId/discovery': typeof ContractsContractIdDiscoveryRoute
   '/contracts/$contractId/explorer': typeof ContractsContractIdExplorerRoute
-  '/contracts/$contractId/inspect': typeof ContractsContractIdInspectRouteWithChildren
   '/contracts/$contractId': typeof ContractsContractIdIndexRoute
   '/contracts/$contractId/inspect/$keyPath': typeof ContractsContractIdInspectKeyPathRoute
+  '/contracts/$contractId/inspect': typeof ContractsContractIdInspectIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -103,6 +111,7 @@ export interface FileRoutesById {
   '/contracts/$contractId/inspect': typeof ContractsContractIdInspectRouteWithChildren
   '/contracts/$contractId/': typeof ContractsContractIdIndexRoute
   '/contracts/$contractId/inspect/$keyPath': typeof ContractsContractIdInspectKeyPathRoute
+  '/contracts/$contractId/inspect/': typeof ContractsContractIdInspectIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -116,6 +125,7 @@ export interface FileRouteTypes {
     | '/contracts/$contractId/inspect'
     | '/contracts/$contractId/'
     | '/contracts/$contractId/inspect/$keyPath'
+    | '/contracts/$contractId/inspect/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -124,9 +134,9 @@ export interface FileRouteTypes {
     | '/settings/preferences'
     | '/contracts/$contractId/discovery'
     | '/contracts/$contractId/explorer'
-    | '/contracts/$contractId/inspect'
     | '/contracts/$contractId'
     | '/contracts/$contractId/inspect/$keyPath'
+    | '/contracts/$contractId/inspect'
   id:
     | '__root__'
     | '/'
@@ -138,6 +148,7 @@ export interface FileRouteTypes {
     | '/contracts/$contractId/inspect'
     | '/contracts/$contractId/'
     | '/contracts/$contractId/inspect/$keyPath'
+    | '/contracts/$contractId/inspect/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -209,6 +220,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ContractsContractIdDiscoveryRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/contracts/$contractId/inspect/': {
+      id: '/contracts/$contractId/inspect/'
+      path: '/'
+      fullPath: '/contracts/$contractId/inspect/'
+      preLoaderRoute: typeof ContractsContractIdInspectIndexRouteImport
+      parentRoute: typeof ContractsContractIdInspectRoute
+    }
     '/contracts/$contractId/inspect/$keyPath': {
       id: '/contracts/$contractId/inspect/$keyPath'
       path: '/$keyPath'
@@ -221,12 +239,14 @@ declare module '@tanstack/react-router' {
 
 interface ContractsContractIdInspectRouteChildren {
   ContractsContractIdInspectKeyPathRoute: typeof ContractsContractIdInspectKeyPathRoute
+  ContractsContractIdInspectIndexRoute: typeof ContractsContractIdInspectIndexRoute
 }
 
 const ContractsContractIdInspectRouteChildren: ContractsContractIdInspectRouteChildren =
   {
     ContractsContractIdInspectKeyPathRoute:
       ContractsContractIdInspectKeyPathRoute,
+    ContractsContractIdInspectIndexRoute: ContractsContractIdInspectIndexRoute,
   }
 
 const ContractsContractIdInspectRouteWithChildren =

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as ContractsContractIdIndexRouteImport } from './routes/contracts
 import { Route as ContractsContractIdInspectRouteImport } from './routes/contracts/$contractId/inspect'
 import { Route as ContractsContractIdExplorerRouteImport } from './routes/contracts/$contractId/explorer'
 import { Route as ContractsContractIdDiscoveryRouteImport } from './routes/contracts/$contractId/discovery'
+import { Route as ContractsContractIdInspectKeyPathRouteImport } from './routes/contracts/$contractId/inspect.$keyPath'
 
 const SdsDemoRoute = SdsDemoRouteImport.update({
   id: '/sds-demo',
@@ -62,6 +63,12 @@ const ContractsContractIdDiscoveryRoute =
     path: '/contracts/$contractId/discovery',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ContractsContractIdInspectKeyPathRoute =
+  ContractsContractIdInspectKeyPathRouteImport.update({
+    id: '/$keyPath',
+    path: '/$keyPath',
+    getParentRoute: () => ContractsContractIdInspectRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -70,8 +77,9 @@ export interface FileRoutesByFullPath {
   '/settings/preferences': typeof SettingsPreferencesRoute
   '/contracts/$contractId/discovery': typeof ContractsContractIdDiscoveryRoute
   '/contracts/$contractId/explorer': typeof ContractsContractIdExplorerRoute
-  '/contracts/$contractId/inspect': typeof ContractsContractIdInspectRoute
+  '/contracts/$contractId/inspect': typeof ContractsContractIdInspectRouteWithChildren
   '/contracts/$contractId/': typeof ContractsContractIdIndexRoute
+  '/contracts/$contractId/inspect/$keyPath': typeof ContractsContractIdInspectKeyPathRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -80,8 +88,9 @@ export interface FileRoutesByTo {
   '/settings/preferences': typeof SettingsPreferencesRoute
   '/contracts/$contractId/discovery': typeof ContractsContractIdDiscoveryRoute
   '/contracts/$contractId/explorer': typeof ContractsContractIdExplorerRoute
-  '/contracts/$contractId/inspect': typeof ContractsContractIdInspectRoute
+  '/contracts/$contractId/inspect': typeof ContractsContractIdInspectRouteWithChildren
   '/contracts/$contractId': typeof ContractsContractIdIndexRoute
+  '/contracts/$contractId/inspect/$keyPath': typeof ContractsContractIdInspectKeyPathRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -91,8 +100,9 @@ export interface FileRoutesById {
   '/settings/preferences': typeof SettingsPreferencesRoute
   '/contracts/$contractId/discovery': typeof ContractsContractIdDiscoveryRoute
   '/contracts/$contractId/explorer': typeof ContractsContractIdExplorerRoute
-  '/contracts/$contractId/inspect': typeof ContractsContractIdInspectRoute
+  '/contracts/$contractId/inspect': typeof ContractsContractIdInspectRouteWithChildren
   '/contracts/$contractId/': typeof ContractsContractIdIndexRoute
+  '/contracts/$contractId/inspect/$keyPath': typeof ContractsContractIdInspectKeyPathRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -105,6 +115,7 @@ export interface FileRouteTypes {
     | '/contracts/$contractId/explorer'
     | '/contracts/$contractId/inspect'
     | '/contracts/$contractId/'
+    | '/contracts/$contractId/inspect/$keyPath'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -115,6 +126,7 @@ export interface FileRouteTypes {
     | '/contracts/$contractId/explorer'
     | '/contracts/$contractId/inspect'
     | '/contracts/$contractId'
+    | '/contracts/$contractId/inspect/$keyPath'
   id:
     | '__root__'
     | '/'
@@ -125,6 +137,7 @@ export interface FileRouteTypes {
     | '/contracts/$contractId/explorer'
     | '/contracts/$contractId/inspect'
     | '/contracts/$contractId/'
+    | '/contracts/$contractId/inspect/$keyPath'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -134,7 +147,7 @@ export interface RootRouteChildren {
   SettingsPreferencesRoute: typeof SettingsPreferencesRoute
   ContractsContractIdDiscoveryRoute: typeof ContractsContractIdDiscoveryRoute
   ContractsContractIdExplorerRoute: typeof ContractsContractIdExplorerRoute
-  ContractsContractIdInspectRoute: typeof ContractsContractIdInspectRoute
+  ContractsContractIdInspectRoute: typeof ContractsContractIdInspectRouteWithChildren
   ContractsContractIdIndexRoute: typeof ContractsContractIdIndexRoute
 }
 
@@ -196,8 +209,30 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ContractsContractIdDiscoveryRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/contracts/$contractId/inspect/$keyPath': {
+      id: '/contracts/$contractId/inspect/$keyPath'
+      path: '/$keyPath'
+      fullPath: '/contracts/$contractId/inspect/$keyPath'
+      preLoaderRoute: typeof ContractsContractIdInspectKeyPathRouteImport
+      parentRoute: typeof ContractsContractIdInspectRoute
+    }
   }
 }
+
+interface ContractsContractIdInspectRouteChildren {
+  ContractsContractIdInspectKeyPathRoute: typeof ContractsContractIdInspectKeyPathRoute
+}
+
+const ContractsContractIdInspectRouteChildren: ContractsContractIdInspectRouteChildren =
+  {
+    ContractsContractIdInspectKeyPathRoute:
+      ContractsContractIdInspectKeyPathRoute,
+  }
+
+const ContractsContractIdInspectRouteWithChildren =
+  ContractsContractIdInspectRoute._addFileChildren(
+    ContractsContractIdInspectRouteChildren,
+  )
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
@@ -206,7 +241,7 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsPreferencesRoute: SettingsPreferencesRoute,
   ContractsContractIdDiscoveryRoute: ContractsContractIdDiscoveryRoute,
   ContractsContractIdExplorerRoute: ContractsContractIdExplorerRoute,
-  ContractsContractIdInspectRoute: ContractsContractIdInspectRoute,
+  ContractsContractIdInspectRoute: ContractsContractIdInspectRouteWithChildren,
   ContractsContractIdIndexRoute: ContractsContractIdIndexRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/contracts/$contractId/explorer.tsx
+++ b/src/routes/contracts/$contractId/explorer.tsx
@@ -39,6 +39,7 @@ function ContractExplorer() {
   const { contractId } = Route.useParams()
   const { normalizedContractId } = Route.useRouteContext()
   const search = Route.useSearch()
+  const navigate = Route.useNavigate()
 
   const setActiveContractId = useLensStore((state) => state.setActiveContractId)
   const setContractLoadStatus = useLensStore(
@@ -50,6 +51,8 @@ function ContractExplorer() {
   const contractLoadError = useLensStore((state) => state.contractLoadError)
   const expandedNodes = useLensStore((state) => state.expandedNodes)
   const toggleExpanded = useLensStore((state) => state.toggleExpanded)
+  const selectedKeyPath = useLensStore((state) => state.selectedKeyPath)
+  const setSelectedKeyPath = useLensStore((state) => state.setSelectedKeyPath)
 
   const ledgerEntries = useLensStore((state) =>
     selectLedgerEntriesByContractId(state, contractId),
@@ -114,6 +117,14 @@ function ContractExplorer() {
     }
 
     void loadContract(contractId, keys)
+  }
+
+  const handleActivateRow = (keyPath: string) => {
+    setSelectedKeyPath(keyPath)
+    void navigate({
+      to: '/contracts/$contractId/inspect/$keyPath',
+      params: { contractId, keyPath },
+    })
   }
 
   return (
@@ -217,6 +228,8 @@ function ContractExplorer() {
                 rows={flatRows}
                 expandedNodeIds={expandedNodes}
                 onToggleExpand={toggleExpanded}
+                selectedRowId={selectedKeyPath}
+                onActivateRow={(row) => handleActivateRow(row.keyPath)}
               />
             )}
           </div>

--- a/src/routes/contracts/$contractId/inspect.$keyPath.tsx
+++ b/src/routes/contracts/$contractId/inspect.$keyPath.tsx
@@ -2,28 +2,29 @@ import { createFileRoute } from '@tanstack/react-router'
 import { InspectShell } from '../../../components/explorer/InspectShell'
 import { validateContractRouteParam } from './-validateContractRouteParam'
 
-export const Route = createFileRoute('/contracts/$contractId/inspect')({
-  component: InspectRoute,
+export const Route = createFileRoute('/contracts/$contractId/inspect/$keyPath')({
+  component: InspectKeyPathRoute,
   beforeLoad: ({ params }) => {
     const result = validateContractRouteParam(params.contractId)
     if (!result.ok) {
       console.error(`Invalid contract ID: ${result.reason}`)
     }
+
     return {
       normalizedContractId: result.ok ? result.contractId : params.contractId,
     }
   },
 })
 
-function InspectRoute() {
-  const { contractId } = Route.useParams()
+function InspectKeyPathRoute() {
+  const { contractId, keyPath } = Route.useParams()
   const { normalizedContractId } = Route.useRouteContext()
 
   return (
     <InspectShell
       contractId={contractId}
       normalizedContractId={normalizedContractId}
-      keyPath=""
+      keyPath={keyPath}
     />
   )
 }

--- a/src/routes/contracts/$contractId/inspect.index.tsx
+++ b/src/routes/contracts/$contractId/inspect.index.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { InspectShell } from '../../../components/explorer/InspectShell'
+
+export const Route = createFileRoute('/contracts/$contractId/inspect/')({
+  component: InspectIndexRoute,
+})
+
+function InspectIndexRoute() {
+  const { contractId } = Route.useParams()
+  const { normalizedContractId } = Route.useRouteContext()
+
+  return (
+    <InspectShell
+      contractId={contractId}
+      normalizedContractId={normalizedContractId}
+      keyPath=""
+    />
+  )
+}

--- a/src/routes/contracts/$contractId/inspect.tsx
+++ b/src/routes/contracts/$contractId/inspect.tsx
@@ -1,9 +1,8 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { InspectShell } from '../../../components/explorer/InspectShell'
+import { Outlet, createFileRoute } from '@tanstack/react-router'
 import { validateContractRouteParam } from './-validateContractRouteParam'
 
 export const Route = createFileRoute('/contracts/$contractId/inspect')({
-  component: InspectRoute,
+  component: InspectLayoutRoute,
   beforeLoad: ({ params }) => {
     const result = validateContractRouteParam(params.contractId)
     if (!result.ok) {
@@ -15,15 +14,6 @@ export const Route = createFileRoute('/contracts/$contractId/inspect')({
   },
 })
 
-function InspectRoute() {
-  const { contractId } = Route.useParams()
-  const { normalizedContractId } = Route.useRouteContext()
-
-  return (
-    <InspectShell
-      contractId={contractId}
-      normalizedContractId={normalizedContractId}
-      keyPath=""
-    />
-  )
+function InspectLayoutRoute() {
+  return <Outlet />
 }

--- a/src/store/contractSlice.ts
+++ b/src/store/contractSlice.ts
@@ -2,15 +2,19 @@ import type { LensStore } from './types'
 
 export type ContractSlice = {
   activeContractId: string | null
+  selectedKeyPath: string | null
 
   setActiveContractId: (id: string) => void
   clearActiveContractId: () => void
+  setSelectedKeyPath: (keyPath: string) => void
+  clearSelectedKeyPath: () => void
 }
 
 export const createContractSlice = (
   set: (fn: (state: LensStore) => Partial<LensStore>) => void,
 ): ContractSlice => ({
   activeContractId: null,
+  selectedKeyPath: null,
 
   setActiveContractId: (id: string) =>
     set(() => ({
@@ -20,5 +24,15 @@ export const createContractSlice = (
   clearActiveContractId: () =>
     set(() => ({
       activeContractId: null,
+    })),
+
+  setSelectedKeyPath: (keyPath: string) =>
+    set(() => ({
+      selectedKeyPath: keyPath,
+    })),
+
+  clearSelectedKeyPath: () =>
+    set(() => ({
+      selectedKeyPath: null,
     })),
 })

--- a/src/store/lensStore.ts
+++ b/src/store/lensStore.ts
@@ -437,6 +437,8 @@ export const useExpandedNodes = () =>
   useLensStore((state) => state.expandedNodes)
 export const useActiveContractId = () =>
   useLensStore((state) => state.activeContractId)
+export const useSelectedKeyPath = () =>
+  useLensStore((state) => state.selectedKeyPath)
 export const useContractLoadStatus = () =>
   useLensStore((state) => state.contractLoadStatus)
 export const useContractLoadError = () =>
@@ -463,6 +465,7 @@ export const resetStore = () => {
     snapshots: {},
     watchlist: {},
     activeContractId: null,
+    selectedKeyPath: null,
     contractLoadStatus: ContractLoadStatus.IDLE,
     contractLoadError: null,
     byteDisplayMode: ByteDisplayMode.HEX,
@@ -500,6 +503,9 @@ export const lensActions = {
   setActiveContractId: (contractId: string) =>
     useLensStore.getState().setActiveContractId(contractId),
   clearActiveContractId: () => useLensStore.getState().clearActiveContractId(),
+  setSelectedKeyPath: (keyPath: string) =>
+    useLensStore.getState().setSelectedKeyPath(keyPath),
+  clearSelectedKeyPath: () => useLensStore.getState().clearSelectedKeyPath(),
   setContractLoadStatus: (status: ContractLoadStatus) =>
     useLensStore.getState().setContractLoadStatus(status),
   setContractLoadError: (message: string | null) =>

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -26,6 +26,7 @@ export const selectIsExpanded = (nodeId: string) => (state: LensStore) =>
   state.expandedNodes.includes(nodeId)
 export const selectExpandedCount = (state: LensStore) =>
   state.expandedNodes.length
+export const selectSelectedKeyPath = (state: LensStore) => state.selectedKeyPath
 
 // Action selectors (for grabbing actions without re-rendering on state changes)
 export const selectSetNetworkConfig = (state: LensStore) =>
@@ -36,3 +37,7 @@ export const selectToggleExpanded = (state: LensStore) => state.toggleExpanded
 export const selectSetExpanded = (state: LensStore) => state.setExpanded
 export const selectExpandAll = (state: LensStore) => state.expandAll
 export const selectCollapseAll = (state: LensStore) => state.collapseAll
+export const selectSetSelectedKeyPath = (state: LensStore) =>
+  state.setSelectedKeyPath
+export const selectClearSelectedKeyPath = (state: LensStore) =>
+  state.clearSelectedKeyPath

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -109,8 +109,11 @@ export interface SnapshotSlice {
 // Contract slice
 export interface ContractSlice {
   activeContractId: string | null
+  selectedKeyPath: string | null
   setActiveContractId: (id: string) => void
   clearActiveContractId: () => void
+  setSelectedKeyPath: (keyPath: string) => void
+  clearSelectedKeyPath: () => void
 }
 
 export enum ContractLoadStatus {

--- a/src/test/components/TreeRow.test.tsx
+++ b/src/test/components/TreeRow.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { TreeRow } from '../../components/explorer/TreeRow'
+import type { FlatTreeRow } from '../../lib/tree/flatTreeRow'
+import type { Node } from '../../types/node'
+
+const primitiveNode: Node = {
+  kind: 'primitive',
+  path: [],
+  scType: 'string',
+  value: 'hello',
+  raw: { switch: 'ScvString' },
+}
+
+function makeRow(partial: Partial<FlatTreeRow> = {}): FlatTreeRow {
+  return {
+    id: 'row-1',
+    parentId: null,
+    depth: 2,
+    keyPath: 'row-1',
+    label: 'entry[0].value',
+    kind: 'primitive',
+    hasChildren: false,
+    childCount: 0,
+    node: primitiveNode,
+    ...partial,
+  }
+}
+
+describe('TreeRow', () => {
+  it('renders indentation spacer for leaf nodes', () => {
+    render(
+      <TreeRow
+        row={makeRow()}
+        rowHeight={40}
+        isExpanded={false}
+        isSelected={false}
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: /toggle/i })).toBeNull()
+    expect(screen.getByText('hello')).toBeTruthy()
+    expect(screen.getByText('string')).toBeTruthy()
+  })
+
+  it('renders expander only for parent rows', () => {
+    const row = makeRow({
+      hasChildren: true,
+      kind: 'vec',
+      node: { kind: 'vec', path: [], items: [], raw: { switch: 'ScvVec' } },
+    })
+
+    render(
+      <TreeRow
+        row={row}
+        rowHeight={40}
+        isExpanded={false}
+        isSelected={false}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Toggle entry[0].value' })).toBeTruthy()
+    expect(screen.getByText('vec')).toBeTruthy()
+    expect(screen.getByText('0 items')).toBeTruthy()
+  })
+
+  it('calls activate handler on row click', () => {
+    const onActivate = vi.fn()
+    const row = makeRow()
+
+    render(
+      <TreeRow
+        row={row}
+        rowHeight={40}
+        isExpanded={false}
+        isSelected={false}
+        onActivate={onActivate}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open entry[0].value' }))
+    expect(onActivate).toHaveBeenCalledWith(row)
+  })
+})

--- a/src/test/components/VirtualizedTreeList.test.tsx
+++ b/src/test/components/VirtualizedTreeList.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { VirtualizedTreeList } from '../../components/explorer/VirtualizedTreeList'
 import type { FlatTreeRow } from '../../lib/tree/flatTreeRow'
 import type { Node } from '../../types/node'
@@ -42,5 +42,21 @@ describe('VirtualizedTreeList', () => {
     fireEvent.scroll(viewport, { target: { scrollTop: 1200 } })
 
     expect(screen.getByText('row-39')).toBeTruthy()
+  })
+
+  it('invokes row activation callback', () => {
+    const onActivateRow = vi.fn()
+
+    render(
+      <VirtualizedTreeList
+        rows={rows(10)}
+        height={200}
+        rowHeight={40}
+        onActivateRow={onActivateRow}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open row-0' }))
+    expect(onActivateRow).toHaveBeenCalled()
   })
 })

--- a/src/test/store/lensStore.test.ts
+++ b/src/test/store/lensStore.test.ts
@@ -26,6 +26,11 @@ describe('lensStore', () => {
       const state = getStoreState()
       expect(state.expandedNodes).toEqual([])
     })
+
+    it('initializes with no selected key path', () => {
+      const state = getStoreState()
+      expect(state.selectedKeyPath).toBeNull()
+    })
   })
 
   describe('networkConfig slice', () => {
@@ -231,6 +236,31 @@ describe('lensStore', () => {
       const state = getStoreState()
       expect(state.ledgerData['test-key']).toBeDefined()
       expect(state.networkConfig.networkId).toBe('futurenet')
+    })
+  })
+
+  describe('selectedKeyPath slice', () => {
+    it('setSelectedKeyPath sets selected path', () => {
+      const { setSelectedKeyPath } = useLensStore.getState()
+
+      setSelectedKeyPath('contract.entry-0-value')
+      expect(getStoreState().selectedKeyPath).toBe('contract.entry-0-value')
+    })
+
+    it('setSelectedKeyPath replaces existing selected path', () => {
+      const { setSelectedKeyPath } = useLensStore.getState()
+
+      setSelectedKeyPath('first.path')
+      setSelectedKeyPath('second.path')
+      expect(getStoreState().selectedKeyPath).toBe('second.path')
+    })
+
+    it('clearSelectedKeyPath clears selected path', () => {
+      const { setSelectedKeyPath, clearSelectedKeyPath } = useLensStore.getState()
+
+      setSelectedKeyPath('first.path')
+      clearSelectedKeyPath()
+      expect(getStoreState().selectedKeyPath).toBeNull()
     })
   })
 })

--- a/src/test/store/selectors.test.ts
+++ b/src/test/store/selectors.test.ts
@@ -20,6 +20,7 @@ import {
   selectNetworkConfig,
   selectNetworkId,
   selectRpcUrl,
+  selectSelectedKeyPath,
 } from '../../store/selectors'
 
 import type { LedgerEntry } from '../../store/types'
@@ -142,6 +143,17 @@ describe('selectors', () => {
     it('selectExpandedCount returns correct count', () => {
       useLensStore.getState().expandAll(['a', 'b', 'c'])
       expect(selectExpandedCount(getStoreState())).toBe(3)
+    })
+  })
+
+  describe('selected key-path selectors', () => {
+    it('selectSelectedKeyPath returns null initially', () => {
+      expect(selectSelectedKeyPath(getStoreState())).toBeNull()
+    })
+
+    it('selectSelectedKeyPath returns selected value', () => {
+      useLensStore.getState().setSelectedKeyPath('root.entry-0-value')
+      expect(selectSelectedKeyPath(getStoreState())).toBe('root.entry-0-value')
     })
   })
 })


### PR DESCRIPTION
Implements tree row rendering with indentation/expander, value preview + type badges, selected key-path store state, dynamic inspect key route, and explorer row activation navigation
Fixes #188
Fixes #189
Fixes #190
Fixes #191
Fixes #192