### PR TITLE
Add watchlist route with empty state and inspect navigation 

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsPreferencesRouteImport } from './routes/settings/preferences'
 import { Route as SettingsNetworkRouteImport } from './routes/settings/network'
 import { Route as ContractsContractIdIndexRouteImport } from './routes/contracts/$contractId/index'
+import { Route as ContractsContractIdWatchlistRouteImport } from './routes/contracts/$contractId/watchlist'
 import { Route as ContractsContractIdInspectRouteImport } from './routes/contracts/$contractId/inspect'
 import { Route as ContractsContractIdExplorerRouteImport } from './routes/contracts/$contractId/explorer'
 import { Route as ContractsContractIdDiscoveryRouteImport } from './routes/contracts/$contractId/discovery'
@@ -44,6 +45,12 @@ const ContractsContractIdIndexRoute =
   ContractsContractIdIndexRouteImport.update({
     id: '/contracts/$contractId/',
     path: '/contracts/$contractId/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ContractsContractIdWatchlistRoute =
+  ContractsContractIdWatchlistRouteImport.update({
+    id: '/contracts/$contractId/watchlist',
+    path: '/contracts/$contractId/watchlist',
     getParentRoute: () => rootRouteImport,
   } as any)
 const ContractsContractIdInspectRoute =
@@ -85,6 +92,7 @@ export interface FileRoutesByFullPath {
   '/contracts/$contractId/discovery': typeof ContractsContractIdDiscoveryRoute
   '/contracts/$contractId/explorer': typeof ContractsContractIdExplorerRoute
   '/contracts/$contractId/inspect': typeof ContractsContractIdInspectRouteWithChildren
+  '/contracts/$contractId/watchlist': typeof ContractsContractIdWatchlistRoute
   '/contracts/$contractId/': typeof ContractsContractIdIndexRoute
   '/contracts/$contractId/inspect/$keyPath': typeof ContractsContractIdInspectKeyPathRoute
   '/contracts/$contractId/inspect/': typeof ContractsContractIdInspectIndexRoute
@@ -96,6 +104,7 @@ export interface FileRoutesByTo {
   '/settings/preferences': typeof SettingsPreferencesRoute
   '/contracts/$contractId/discovery': typeof ContractsContractIdDiscoveryRoute
   '/contracts/$contractId/explorer': typeof ContractsContractIdExplorerRoute
+  '/contracts/$contractId/watchlist': typeof ContractsContractIdWatchlistRoute
   '/contracts/$contractId': typeof ContractsContractIdIndexRoute
   '/contracts/$contractId/inspect/$keyPath': typeof ContractsContractIdInspectKeyPathRoute
   '/contracts/$contractId/inspect': typeof ContractsContractIdInspectIndexRoute
@@ -109,6 +118,7 @@ export interface FileRoutesById {
   '/contracts/$contractId/discovery': typeof ContractsContractIdDiscoveryRoute
   '/contracts/$contractId/explorer': typeof ContractsContractIdExplorerRoute
   '/contracts/$contractId/inspect': typeof ContractsContractIdInspectRouteWithChildren
+  '/contracts/$contractId/watchlist': typeof ContractsContractIdWatchlistRoute
   '/contracts/$contractId/': typeof ContractsContractIdIndexRoute
   '/contracts/$contractId/inspect/$keyPath': typeof ContractsContractIdInspectKeyPathRoute
   '/contracts/$contractId/inspect/': typeof ContractsContractIdInspectIndexRoute
@@ -123,6 +133,7 @@ export interface FileRouteTypes {
     | '/contracts/$contractId/discovery'
     | '/contracts/$contractId/explorer'
     | '/contracts/$contractId/inspect'
+    | '/contracts/$contractId/watchlist'
     | '/contracts/$contractId/'
     | '/contracts/$contractId/inspect/$keyPath'
     | '/contracts/$contractId/inspect/'
@@ -134,6 +145,7 @@ export interface FileRouteTypes {
     | '/settings/preferences'
     | '/contracts/$contractId/discovery'
     | '/contracts/$contractId/explorer'
+    | '/contracts/$contractId/watchlist'
     | '/contracts/$contractId'
     | '/contracts/$contractId/inspect/$keyPath'
     | '/contracts/$contractId/inspect'
@@ -146,6 +158,7 @@ export interface FileRouteTypes {
     | '/contracts/$contractId/discovery'
     | '/contracts/$contractId/explorer'
     | '/contracts/$contractId/inspect'
+    | '/contracts/$contractId/watchlist'
     | '/contracts/$contractId/'
     | '/contracts/$contractId/inspect/$keyPath'
     | '/contracts/$contractId/inspect/'
@@ -159,6 +172,7 @@ export interface RootRouteChildren {
   ContractsContractIdDiscoveryRoute: typeof ContractsContractIdDiscoveryRoute
   ContractsContractIdExplorerRoute: typeof ContractsContractIdExplorerRoute
   ContractsContractIdInspectRoute: typeof ContractsContractIdInspectRouteWithChildren
+  ContractsContractIdWatchlistRoute: typeof ContractsContractIdWatchlistRoute
   ContractsContractIdIndexRoute: typeof ContractsContractIdIndexRoute
 }
 
@@ -197,6 +211,13 @@ declare module '@tanstack/react-router' {
       path: '/contracts/$contractId'
       fullPath: '/contracts/$contractId/'
       preLoaderRoute: typeof ContractsContractIdIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/contracts/$contractId/watchlist': {
+      id: '/contracts/$contractId/watchlist'
+      path: '/contracts/$contractId/watchlist'
+      fullPath: '/contracts/$contractId/watchlist'
+      preLoaderRoute: typeof ContractsContractIdWatchlistRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/contracts/$contractId/inspect': {
@@ -262,6 +283,7 @@ const rootRouteChildren: RootRouteChildren = {
   ContractsContractIdDiscoveryRoute: ContractsContractIdDiscoveryRoute,
   ContractsContractIdExplorerRoute: ContractsContractIdExplorerRoute,
   ContractsContractIdInspectRoute: ContractsContractIdInspectRouteWithChildren,
+  ContractsContractIdWatchlistRoute: ContractsContractIdWatchlistRoute,
   ContractsContractIdIndexRoute: ContractsContractIdIndexRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/contracts/$contractId/watchlist.tsx
+++ b/src/routes/contracts/$contractId/watchlist.tsx
@@ -1,0 +1,96 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { validateContractRouteParam } from './-validateContractRouteParam'
+import { useLensStore } from '../../../store/lensStore'
+import { Button, Card, Heading } from '@stellar/design-system'
+
+export const Route = createFileRoute('/contracts/$contractId/watchlist')({
+  component: RouteComponent,
+  beforeLoad: ({ params }) => {
+    const result = validateContractRouteParam(params.contractId)
+    if (!result.ok) {
+      console.error(`Invalid contract ID: ${result.reason}`)
+      throw redirect({ to: '/' })
+    }
+    return {
+      normalizedContractId: result.ok ? result.contractId : params.contractId,
+    }
+  },
+})
+
+function RouteComponent() {
+  const { contractId } = Route.useParams()
+  const { normalizedContractId } = Route.useRouteContext()
+  const navigate = Route.useNavigate()
+
+  const watchlistItems = useLensStore((state) =>
+    state.getWatchlistForContract(contractId),
+  )
+
+  const handleInspect = (keyPath: string) => {
+    void navigate({
+      to: '/contracts/$contractId/inspect/$keyPath',
+      params: { contractId, keyPath },
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-3 p-6 lg:p-10 max-w-6xl mx-auto w-full">
+      <header className="flex flex-col md:flex-row md:items-end justify-between gap-4 border-b border-border-dark pb-6">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-3">
+            <span className="px-2 py-0.5 rounded bg-primary/20 text-primary text-[10px] font-bold uppercase tracking-wider font-mono">
+              Watchlist
+            </span>
+          </div>
+          <Heading size="lg" as="h1" className="font-mono break-all text-white">
+            {normalizedContractId}
+          </Heading>
+        </div>
+      </header>
+      {watchlistItems.length === 0 ? (
+        <Card>
+          <div className="p-6">
+            <Heading
+              as="h1"
+              size="sm"
+              className="text-text-muted uppercase tracking-widest text-[11px] font-bold"
+            >
+              No watchlist items
+            </Heading>
+            <p className="text-text-muted text-sm">
+              Pin keys from the Inspector to quickly revisit them here.
+            </p>
+          </div>
+        </Card>
+      ) : (
+        watchlistItems.map((item, index) => (
+          <Card key={index}>
+            <div className="border-l-2 border-primary p-3">
+              <div className="text-[10px] font-bold uppercase tracking-widest text-text-muted">
+                Watchlist Item
+              </div>
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 text-sm text-text-muted font-mono">
+                    <span>Contract</span>
+                    <span>/</span>
+                    <span className="text-white break-all">{item.keyPath}</span>
+                  </div>
+                </div>
+
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => handleInspect(item.keyPath)}
+                >
+                  Inspect
+                </Button>
+              </div>
+            </div>
+          </Card>
+        ))
+      )}
+    </div>
+  )
+}

--- a/src/routes/contracts/$contractId/watchlist.tsx
+++ b/src/routes/contracts/$contractId/watchlist.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
-import { validateContractRouteParam } from './-validateContractRouteParam'
-import { useLensStore } from '../../../store/lensStore'
 import { Button, Card, Heading } from '@stellar/design-system'
+import { useLensStore } from '../../../store/lensStore'
+import { validateContractRouteParam } from './-validateContractRouteParam'
 
 export const Route = createFileRoute('/contracts/$contractId/watchlist')({
   component: RouteComponent,
@@ -12,7 +12,7 @@ export const Route = createFileRoute('/contracts/$contractId/watchlist')({
       throw redirect({ to: '/' })
     }
     return {
-      normalizedContractId: result.ok ? result.contractId : params.contractId,
+      normalizedContractId:  result.contractId,
     }
   },
 })


### PR DESCRIPTION
## Summary

- Added the `/contracts/$contractId/watchlist` route
- Added contract ID validation and redirect handling
- Rendered watchlist items for the active contract
- Added a helpful empty state when no watchlist items exist
- Added inspect actions that navigate to the corresponding inspect route
- Styled the page using existing design system components for consistency

## Verification

- Verified the watchlist route loads successfully
- Verified the empty state renders when no items exist
- Verified watchlist items appear after pinning keys from the inspector
- Verified inspect navigation works for saved items
- Ran local checks and confirmed the application builds successfully

Closes #215 