### PR TITLE
fix: validate inspect key paths

### DIFF
--- a/src/components/explorer/InspectShell.tsx
+++ b/src/components/explorer/InspectShell.tsx
@@ -5,6 +5,7 @@ interface InspectShellProps {
   contractId: string
   normalizedContractId: string
   keyPath: string
+  keyPathError?: string
 }
 
 interface KeyMetadata {
@@ -17,6 +18,7 @@ export function InspectShell({
   contractId,
   normalizedContractId,
   keyPath,
+  keyPathError,
 }: InspectShellProps) {
   const addToWatchlist = useLensStore((state) => state.addToWatchlist)
 
@@ -66,6 +68,17 @@ export function InspectShell({
         <span>/</span>
         <span className="text-white truncate">{keyPath || 'No key selected'}</span>
       </div>
+
+      {keyPathError ? (
+        <Card>
+          <div className="p-6 space-y-2">
+            <Heading size="sm" as="h2" className="text-white">
+              Invalid key path
+            </Heading>
+            <p className="text-sm text-text-muted">{keyPathError}</p>
+          </div>
+        </Card>
+      ) : null}
 
       <Card>
         <div className="p-6 space-y-4">

--- a/src/routes/contracts/$contractId/-validateInspectKeyPathParam.ts
+++ b/src/routes/contracts/$contractId/-validateInspectKeyPathParam.ts
@@ -1,0 +1,30 @@
+/**
+ * Stable reason codes for inspect key path validation failures.
+ */
+export type InspectKeyPathValidationReason = 'EMPTY_INPUT'
+
+/**
+ * Discriminated union result for inspect key path route parameter validation.
+ */
+export type ValidateInspectKeyPathParamResult =
+  | { ok: true; keyPath: string }
+  | { ok: false; reason: InspectKeyPathValidationReason }
+
+/**
+ * Validates and normalizes an inspect key path route parameter.
+ *
+ * This deliberately stays lightweight: key path parsing belongs to the decoder
+ * layer, while the route only needs to guard against empty or whitespace-only
+ * params that produce a broken inspector state.
+ */
+export function validateInspectKeyPathParam(
+  keyPathParam: string,
+): ValidateInspectKeyPathParamResult {
+  const keyPath = keyPathParam.trim()
+
+  if (!keyPath) {
+    return { ok: false, reason: 'EMPTY_INPUT' }
+  }
+
+  return { ok: true, keyPath }
+}

--- a/src/routes/contracts/$contractId/inspect.$keyPath.tsx
+++ b/src/routes/contracts/$contractId/inspect.$keyPath.tsx
@@ -1,30 +1,45 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { InspectShell } from '../../../components/explorer/InspectShell'
 import { validateContractRouteParam } from './-validateContractRouteParam'
+import { validateInspectKeyPathParam } from './-validateInspectKeyPathParam'
 
 export const Route = createFileRoute('/contracts/$contractId/inspect/$keyPath')({
   component: InspectKeyPathRoute,
   beforeLoad: ({ params }) => {
-    const result = validateContractRouteParam(params.contractId)
-    if (!result.ok) {
-      console.error(`Invalid contract ID: ${result.reason}`)
+    const contractResult = validateContractRouteParam(params.contractId)
+    const keyPathResult = validateInspectKeyPathParam(params.keyPath)
+
+    if (!contractResult.ok) {
+      console.error(`Invalid contract ID: ${contractResult.reason}`)
+    }
+
+    if (!keyPathResult.ok) {
+      console.error(`Invalid inspect key path: ${keyPathResult.reason}`)
     }
 
     return {
-      normalizedContractId: result.ok ? result.contractId : params.contractId,
+      keyPath: keyPathResult.ok ? keyPathResult.keyPath : '',
+      keyPathError: keyPathResult.ok
+        ? undefined
+        : 'Key path must be a non-empty value.',
+      normalizedContractId: contractResult.ok
+        ? contractResult.contractId
+        : params.contractId,
     }
   },
 })
 
 function InspectKeyPathRoute() {
-  const { contractId, keyPath } = Route.useParams()
-  const { normalizedContractId } = Route.useRouteContext()
+  const { contractId } = Route.useParams()
+  const { keyPath, keyPathError, normalizedContractId } =
+    Route.useRouteContext()
 
   return (
     <InspectShell
       contractId={contractId}
       normalizedContractId={normalizedContractId}
       keyPath={keyPath}
+      keyPathError={keyPathError}
     />
   )
 }

--- a/src/test/routes/validateInspectKeyPathParam.test.ts
+++ b/src/test/routes/validateInspectKeyPathParam.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { validateInspectKeyPathParam } from '../../routes/contracts/$contractId/-validateInspectKeyPathParam'
+
+describe('validateInspectKeyPathParam', () => {
+  it('should accept a non-empty key path', () => {
+    expect(validateInspectKeyPathParam('ledger-key-1')).toEqual({
+      ok: true,
+      keyPath: 'ledger-key-1',
+    })
+  })
+
+  it('should trim surrounding whitespace for valid key paths', () => {
+    expect(validateInspectKeyPathParam('  ledger-key-1  ')).toEqual({
+      ok: true,
+      keyPath: 'ledger-key-1',
+    })
+  })
+
+  it('should reject an empty key path', () => {
+    expect(validateInspectKeyPathParam('')).toEqual({
+      ok: false,
+      reason: 'EMPTY_INPUT',
+    })
+  })
+
+  it('should reject whitespace-only key paths', () => {
+    expect(validateInspectKeyPathParam('   ')).toEqual({
+      ok: false,
+      reason: 'EMPTY_INPUT',
+    })
+  })
+})


### PR DESCRIPTION
Closes #296

Summary:
- Adds route-level validation for empty or whitespace-only inspect key paths.
- Keeps the inspect route on a safe empty selection state with a clear invalid key path message.
- Adds focused Vitest coverage for the key path validator.

Verification:
- git diff --check
- npm test -- --run src/test/routes/validateInspectKeyPathParam.test.ts (blocked locally: this fresh clone has no node_modules/vitest installed, and bun is not installed in PATH)