### PR TITLE
feat: make getLatestLedger connection timeout configurable; memoize s…

### DIFF
--- a/src/lib/network/getLatestLedger.ts
+++ b/src/lib/network/getLatestLedger.ts
@@ -46,12 +46,13 @@ function parseLatestLedgerResult(value: unknown): LatestLedgerResult | null {
 
 export async function getLatestLedgerConnectionCheck(
   url: string,
+  timeoutMs?: number,
 ): Promise<GetLatestLedgerConnectionResult> {
   try {
     const response = await callRpc(
       {
         url,
-        timeout: 5000,
+        timeout: timeoutMs ?? 5000,
       },
       buildJsonRpcRequest('getLatestLedger', {}, toRpcRequestId()),
     )

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -15,7 +15,7 @@ export const selectLedgerEntry = (key: string) => (state: LensStore) =>
 // Memoize filtered ledger entries per contractId by ledgerData reference.
 const _ledgerEntriesByContractCache: Map<
   string,
-  { ledgerDataRef: LensStore['ledgerData'] | null; result: LensStore['ledgerData'][string][] }
+  { ledgerDataRef: LensStore['ledgerData'] | null; result: Array<LensStore['ledgerData'][string]> }
 > = new Map()
 
 export const selectLedgerEntriesByContract = (contractId: string) => (

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -12,9 +12,33 @@ export const selectHorizonUrl = (state: LensStore) =>
 export const selectLedgerData = (state: LensStore) => state.ledgerData
 export const selectLedgerEntry = (key: string) => (state: LensStore) =>
   state.ledgerData[key] as LensStore['ledgerData'][string] | undefined
-export const selectLedgerEntriesByContract =
-  (contractId: string) => (state: LensStore) =>
-    Object.values(state.ledgerData).filter((e) => e.contractId === contractId)
+// Memoize filtered ledger entries per contractId by ledgerData reference.
+const _ledgerEntriesByContractCache: Map<
+  string,
+  { ledgerDataRef: LensStore['ledgerData'] | null; result: LensStore['ledgerData'][string][] }
+> = new Map()
+
+export const selectLedgerEntriesByContract = (contractId: string) => (
+  state: LensStore,
+) => {
+  const ledgerData = state.ledgerData
+  const cached = _ledgerEntriesByContractCache.get(contractId)
+
+  if (cached && cached.ledgerDataRef === ledgerData) {
+    return cached.result
+  }
+
+  const result = Object.values(ledgerData).filter(
+    (e) => e.contractId === contractId,
+  )
+
+  _ledgerEntriesByContractCache.set(contractId, {
+    ledgerDataRef: ledgerData,
+    result,
+  })
+
+  return result
+}
 export const selectLedgerEntryCount = (state: LensStore) =>
   Object.keys(state.ledgerData).length
 export const selectHasLedgerData = (state: LensStore) =>

--- a/src/test/network/getLatestLedger.test.ts
+++ b/src/test/network/getLatestLedger.test.ts
@@ -34,6 +34,40 @@ describe('getLatestLedgerConnectionCheck', () => {
     )
   })
 
+  it('allows specifying a custom timeout', async () => {
+    const spy = vi.spyOn(rpcClient, 'callRpc').mockResolvedValue({
+      jsonrpc: '2.0',
+      id: 7,
+      result: {
+        id: 'abc123',
+        protocolVersion: 23,
+        sequence: 987654,
+      },
+    })
+
+    const result = await getLatestLedgerConnectionCheck(
+      'https://valid-rpc.com',
+      1234,
+    )
+
+    expect(result).toEqual({
+      success: true,
+      ledger: {
+        id: 'abc123',
+        protocolVersion: 23,
+        sequence: 987654,
+      },
+    })
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ url: 'https://valid-rpc.com', timeout: 1234 }),
+      expect.objectContaining({
+        jsonrpc: '2.0',
+        method: 'getLatestLedger',
+        params: {},
+      }),
+    )
+  })
+
   it('returns a handled failure when the endpoint is unreachable', async () => {
     vi.spyOn(rpcClient, 'callRpc').mockResolvedValue({
       message: 'Network error',

--- a/src/test/store/selectors.test.ts
+++ b/src/test/store/selectors.test.ts
@@ -112,6 +112,33 @@ describe('selectors', () => {
       expect(def).toHaveLength(1)
     })
 
+    it('selectLedgerEntriesByContract is referentially stable across identical state reads', () => {
+      useLensStore
+        .getState()
+        .upsertLedgerEntries([mockEntry, mockEntry2, mockEntry3])
+
+      const first = selectLedgerEntriesByContract('ABC123')(getStoreState())
+      const second = selectLedgerEntriesByContract('ABC123')(getStoreState())
+
+      expect(first).toBe(second)
+    })
+
+    it('selectLedgerEntriesByContract recomputes after ledger upsert', () => {
+      useLensStore
+        .getState()
+        .upsertLedgerEntries([mockEntry, mockEntry2, mockEntry3])
+
+      const first = selectLedgerEntriesByContract('ABC123')(getStoreState())
+
+      const newEntry = { ...mockEntry, key: 'contract:ABC123:New', lastModifiedLedger: 200 }
+      useLensStore.getState().upsertLedgerEntry(newEntry)
+
+      const second = selectLedgerEntriesByContract('ABC123')(getStoreState())
+
+      expect(second).not.toBe(first)
+      expect(second.map((e) => e.key)).toContain(newEntry.key)
+    })
+
     it('selectLedgerEntryCount returns correct count', () => {
       expect(selectLedgerEntryCount(getStoreState())).toBe(0)
 


### PR DESCRIPTION
Summary:

Adds an optional timeout parameter to the [getLatestLedgerConnectionCheck](vscode-file://vscode-app/c:/Users/PC/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) helper so callers can shorten/lengthen the connection-check timeout (default remains 5000ms).
Adds shallow-reference memoization for [selectLedgerEntriesByContract](vscode-file://vscode-app/c:/Users/PC/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so repeated reads return the same array reference when [ledgerData](vscode-file://vscode-app/c:/Users/PC/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) hasn't changed.


closes #293
closes #286