### PR TITLE
fix: redirect to home on invalid contract ID in child routes

### DIFF
--- a/src/routes/contracts/$contractId/discovery.tsx
+++ b/src/routes/contracts/$contractId/discovery.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 import { Card, Heading, IconButton } from '@stellar/design-system'
 import { useLensStore } from '../../../store/lensStore'
 import { validateContractRouteParam } from './-validateContractRouteParam'
@@ -8,10 +8,10 @@ export const Route = createFileRoute('/contracts/$contractId/discovery')({
   beforeLoad: ({ params }) => {
     const result = validateContractRouteParam(params.contractId)
     if (!result.ok) {
-      console.error(`Invalid contract ID: ${result.reason}`)
+      throw redirect({ to: '/' })
     }
     return {
-      normalizedContractId: result.ok ? result.contractId : params.contractId,
+      normalizedContractId: result.contractId,
     }
   },
 })

--- a/src/routes/contracts/$contractId/explorer.tsx
+++ b/src/routes/contracts/$contractId/explorer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 import { Button, Card, Heading } from '@stellar/design-system'
 import { VirtualizedTreeList } from '../../../components/explorer/VirtualizedTreeList'
 import { selectLedgerEntriesByContractId } from '../../../lib/selectors/selectLedgerEntriesByContractId'
@@ -27,10 +27,10 @@ export const Route = createFileRoute('/contracts/$contractId/explorer')({
   beforeLoad: ({ params }) => {
     const result = validateContractRouteParam(params.contractId)
     if (!result.ok) {
-      console.error(`Invalid contract ID: ${result.reason}`)
+      throw redirect({ to: '/' })
     }
     return {
-      normalizedContractId: result.ok ? result.contractId : params.contractId,
+      normalizedContractId: result.contractId,
     }
   },
 })

--- a/src/routes/contracts/$contractId/inspect.tsx
+++ b/src/routes/contracts/$contractId/inspect.tsx
@@ -1,4 +1,4 @@
-import { Outlet, createFileRoute } from '@tanstack/react-router'
+import { Outlet, createFileRoute, redirect } from '@tanstack/react-router'
 import { validateContractRouteParam } from './-validateContractRouteParam'
 
 export const Route = createFileRoute('/contracts/$contractId/inspect')({
@@ -6,10 +6,10 @@ export const Route = createFileRoute('/contracts/$contractId/inspect')({
   beforeLoad: ({ params }) => {
     const result = validateContractRouteParam(params.contractId)
     if (!result.ok) {
-      console.error(`Invalid contract ID: ${result.reason}`)
+      throw redirect({ to: '/' })
     }
     return {
-      normalizedContractId: result.ok ? result.contractId : params.contractId,
+      normalizedContractId: result.contractId,
     }
   },
 })


### PR DESCRIPTION
Explorer, inspect, and discovery beforeLoad hooks now throw redirect({ to: '/' }) on invalid contract IDs, matching the behavior of the index route.

Closes #297