### PR TITLE
Feature/add ledger poller jitter

### DIFF
--- a/src/lib/network/ledgerPoller.ts
+++ b/src/lib/network/ledgerPoller.ts
@@ -1,5 +1,6 @@
 import { buildJsonRpcRequest } from '../rpc/buildJsonRpcRequest'
 import { toRpcRequestId } from '../rpc/toRpcRequestId'
+import { withJitter } from '../rpc/withJitter'
 import { callRpc } from './rpcClient'
 import type { LatestLedgerResult, RpcConfig, RpcError } from './types'
 
@@ -61,12 +62,27 @@ export function startLedgerHeadPoll(
     }
   }
 
-  const intervalId = setInterval(tick, intervalMs)
+  let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+  const scheduleNextPoll = (): void => {
+    if (stoppedRef.current) return
+
+    const delayMs = withJitter(intervalMs)
+    timeoutId = setTimeout(async () => {
+      if (stoppedRef.current) return
+      await tick()
+      scheduleNextPoll()
+    }, delayMs)
+  }
+
   tick()
+  scheduleNextPoll()
 
   return function stop(): void {
     if (stoppedRef.current) return
     stoppedRef.current = true
-    clearInterval(intervalId)
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId)
+    }
   }
 }

--- a/src/test/network/ledgerPoller.test.ts
+++ b/src/test/network/ledgerPoller.test.ts
@@ -133,6 +133,7 @@ describe('startLedgerHeadPoll', () => {
   describe('stop function', () => {
     it('halts further polling and callbacks after stop', async () => {
       const onLedgerChange = vi.fn()
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
       mockCallRpc
         .mockResolvedValueOnce({ result: { sequence: 100 } })
         .mockResolvedValueOnce({ result: { sequence: 101 } })
@@ -155,6 +156,7 @@ describe('startLedgerHeadPoll', () => {
       await vi.advanceTimersByTimeAsync(5000)
       expect(mockCallRpc).toHaveBeenCalledTimes(3)
       expect(onLedgerChange).toHaveBeenCalledTimes(3)
+      randomSpy.mockRestore()
     })
 
     it('stop is idempotent', async () => {
@@ -176,6 +178,7 @@ describe('startLedgerHeadPoll', () => {
 
   describe('configurable options', () => {
     it('uses default interval 5000ms when intervalMs omitted', async () => {
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
       mockCallRpc.mockResolvedValue({ result: { sequence: 1 } })
       const onLedgerChange = vi.fn()
 
@@ -189,9 +192,11 @@ describe('startLedgerHeadPoll', () => {
       expect(mockCallRpc).toHaveBeenCalledTimes(1)
       await vi.advanceTimersByTimeAsync(1)
       expect(mockCallRpc).toHaveBeenCalledTimes(2)
+      randomSpy.mockRestore()
     })
 
     it('uses custom interval when intervalMs provided', async () => {
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
       mockCallRpc.mockResolvedValue({ result: { sequence: 1 } })
 
       startLedgerHeadPoll({
@@ -205,6 +210,48 @@ describe('startLedgerHeadPoll', () => {
       expect(mockCallRpc).toHaveBeenCalledTimes(1)
       await vi.advanceTimersByTimeAsync(1)
       expect(mockCallRpc).toHaveBeenCalledTimes(2)
+      randomSpy.mockRestore()
+    })
+
+    it('jittered interval stays within expected bounds', async () => {
+      const timeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+      const randomSpy = vi
+        .spyOn(Math, 'random')
+        .mockReturnValueOnce(0.1)
+        .mockReturnValueOnce(0.5)
+        .mockReturnValueOnce(0.9)
+      mockCallRpc.mockResolvedValue({ result: { sequence: 1 } })
+
+      const stop = startLedgerHeadPoll({
+        rpcConfig: defaultRpcConfig,
+        intervalMs: 1000,
+        onLedgerChange: vi.fn(),
+      })
+
+      expect(timeoutSpy).toHaveBeenCalledTimes(1)
+      const firstDelay = timeoutSpy.mock.calls[0][1] as number
+      expect(firstDelay).toBeGreaterThanOrEqual(800)
+      expect(firstDelay).toBeLessThanOrEqual(1200)
+
+      await vi.advanceTimersByTimeAsync(firstDelay)
+      expect(mockCallRpc).toHaveBeenCalledTimes(2)
+      expect(timeoutSpy).toHaveBeenCalledTimes(2)
+
+      const secondDelay = timeoutSpy.mock.calls[1][1] as number
+      expect(secondDelay).toBeGreaterThanOrEqual(800)
+      expect(secondDelay).toBeLessThanOrEqual(1200)
+
+      await vi.advanceTimersByTimeAsync(secondDelay)
+      expect(mockCallRpc).toHaveBeenCalledTimes(3)
+      expect(timeoutSpy).toHaveBeenCalledTimes(3)
+
+      const thirdDelay = timeoutSpy.mock.calls[2][1] as number
+      expect(thirdDelay).toBeGreaterThanOrEqual(800)
+      expect(thirdDelay).toBeLessThanOrEqual(1200)
+
+      stop()
+      randomSpy.mockRestore()
+      timeoutSpy.mockRestore()
     })
 
     it('passes rpcConfig to callRpc', async () => {

--- a/src/test/network/ledgerPoller.test.ts
+++ b/src/test/network/ledgerPoller.test.ts
@@ -26,6 +26,7 @@ describe('startLedgerHeadPoll', () => {
   describe('emits changes only on sequence increment', () => {
     it('calls onLedgerChange when sequence increases', async () => {
       const onLedgerChange = vi.fn()
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
       mockCallRpc
         .mockResolvedValueOnce({ result: { sequence: 100 } })
         .mockResolvedValueOnce({ result: { sequence: 101 } })
@@ -45,10 +46,12 @@ describe('startLedgerHeadPoll', () => {
       expect(onLedgerChange).toHaveBeenCalledWith(102)
       expect(onLedgerChange).toHaveBeenCalledTimes(3)
       stop()
+      randomSpy.mockRestore()
     })
 
     it('does not call onLedgerChange when sequence is unchanged', async () => {
       const onLedgerChange = vi.fn()
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
       mockCallRpc
         .mockResolvedValueOnce({ result: { sequence: 100 } })
         .mockResolvedValueOnce({ result: { sequence: 100 } })
@@ -67,10 +70,12 @@ describe('startLedgerHeadPoll', () => {
       await vi.advanceTimersByTimeAsync(1000)
       expect(onLedgerChange).toHaveBeenCalledTimes(1)
       stop()
+      randomSpy.mockRestore()
     })
 
     it('does not call onLedgerChange when sequence decreases', async () => {
       const onLedgerChange = vi.fn()
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
       mockCallRpc
         .mockResolvedValueOnce({ result: { sequence: 102 } })
         .mockResolvedValueOnce({ result: { sequence: 101 } })
@@ -88,10 +93,12 @@ describe('startLedgerHeadPoll', () => {
       await vi.advanceTimersByTimeAsync(1000)
       expect(onLedgerChange).toHaveBeenCalledTimes(1)
       stop()
+      randomSpy.mockRestore()
     })
 
     it('calls onLedgerChange only for first poll when result has no sequence then valid sequence', async () => {
       const onLedgerChange = vi.fn()
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
       mockCallRpc
         .mockResolvedValueOnce({ result: {} })
         .mockResolvedValueOnce({ result: { sequence: 100 } })
@@ -108,10 +115,12 @@ describe('startLedgerHeadPoll', () => {
       expect(onLedgerChange).toHaveBeenCalledTimes(1)
       expect(onLedgerChange).toHaveBeenCalledWith(100)
       stop()
+      randomSpy.mockRestore()
     })
 
     it('does not call onLedgerChange when RPC returns error', async () => {
       const onLedgerChange = vi.fn()
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
       mockCallRpc.mockResolvedValue({
         message: 'Network error',
         code: 'NETWORK_ERROR',
@@ -127,6 +136,7 @@ describe('startLedgerHeadPoll', () => {
       await vi.advanceTimersByTimeAsync(1000)
       expect(onLedgerChange).not.toHaveBeenCalled()
       stop()
+      randomSpy.mockRestore()
     })
   })
 


### PR DESCRIPTION
Summary
This change adds jitter to the ledger head poller so repeated getLatestLedger polling does not occur on a fixed interval. The poller now uses the existing [withJitter](vscode-file://vscode-app/c:/Users/PC/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) helper to vary each delay around the configured base interval.


closes #284