### PR TITLE
fix : Clear active contract context when leaving contract routes

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SdsDemoRouteImport } from './routes/sds-demo'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsPreferencesRouteImport } from './routes/settings/preferences'
 import { Route as SettingsNetworkRouteImport } from './routes/settings/network'
+import { Route as ContractsContractIdRouteImport } from './routes/contracts/$contractId'
 import { Route as ContractsContractIdIndexRouteImport } from './routes/contracts/$contractId/index'
 import { Route as ContractsContractIdInspectRouteImport } from './routes/contracts/$contractId/inspect'
 import { Route as ContractsContractIdExplorerRouteImport } from './routes/contracts/$contractId/explorer'
@@ -40,29 +41,34 @@ const SettingsNetworkRoute = SettingsNetworkRouteImport.update({
   path: '/settings/network',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ContractsContractIdRoute = ContractsContractIdRouteImport.update({
+  id: '/contracts/$contractId',
+  path: '/contracts/$contractId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ContractsContractIdIndexRoute =
   ContractsContractIdIndexRouteImport.update({
-    id: '/contracts/$contractId/',
-    path: '/contracts/$contractId/',
-    getParentRoute: () => rootRouteImport,
+    id: '/',
+    path: '/',
+    getParentRoute: () => ContractsContractIdRoute,
   } as any)
 const ContractsContractIdInspectRoute =
   ContractsContractIdInspectRouteImport.update({
-    id: '/contracts/$contractId/inspect',
-    path: '/contracts/$contractId/inspect',
-    getParentRoute: () => rootRouteImport,
+    id: '/inspect',
+    path: '/inspect',
+    getParentRoute: () => ContractsContractIdRoute,
   } as any)
 const ContractsContractIdExplorerRoute =
   ContractsContractIdExplorerRouteImport.update({
-    id: '/contracts/$contractId/explorer',
-    path: '/contracts/$contractId/explorer',
-    getParentRoute: () => rootRouteImport,
+    id: '/explorer',
+    path: '/explorer',
+    getParentRoute: () => ContractsContractIdRoute,
   } as any)
 const ContractsContractIdDiscoveryRoute =
   ContractsContractIdDiscoveryRouteImport.update({
-    id: '/contracts/$contractId/discovery',
-    path: '/contracts/$contractId/discovery',
-    getParentRoute: () => rootRouteImport,
+    id: '/discovery',
+    path: '/discovery',
+    getParentRoute: () => ContractsContractIdRoute,
   } as any)
 const ContractsContractIdInspectIndexRoute =
   ContractsContractIdInspectIndexRouteImport.update({
@@ -80,6 +86,7 @@ const ContractsContractIdInspectKeyPathRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/sds-demo': typeof SdsDemoRoute
+  '/contracts/$contractId': typeof ContractsContractIdRouteWithChildren
   '/settings/network': typeof SettingsNetworkRoute
   '/settings/preferences': typeof SettingsPreferencesRoute
   '/contracts/$contractId/discovery': typeof ContractsContractIdDiscoveryRoute
@@ -104,6 +111,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/sds-demo': typeof SdsDemoRoute
+  '/contracts/$contractId': typeof ContractsContractIdRouteWithChildren
   '/settings/network': typeof SettingsNetworkRoute
   '/settings/preferences': typeof SettingsPreferencesRoute
   '/contracts/$contractId/discovery': typeof ContractsContractIdDiscoveryRoute
@@ -118,6 +126,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/sds-demo'
+    | '/contracts/$contractId'
     | '/settings/network'
     | '/settings/preferences'
     | '/contracts/$contractId/discovery'
@@ -141,6 +150,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/sds-demo'
+    | '/contracts/$contractId'
     | '/settings/network'
     | '/settings/preferences'
     | '/contracts/$contractId/discovery'
@@ -154,12 +164,9 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   SdsDemoRoute: typeof SdsDemoRoute
+  ContractsContractIdRoute: typeof ContractsContractIdRouteWithChildren
   SettingsNetworkRoute: typeof SettingsNetworkRoute
   SettingsPreferencesRoute: typeof SettingsPreferencesRoute
-  ContractsContractIdDiscoveryRoute: typeof ContractsContractIdDiscoveryRoute
-  ContractsContractIdExplorerRoute: typeof ContractsContractIdExplorerRoute
-  ContractsContractIdInspectRoute: typeof ContractsContractIdInspectRouteWithChildren
-  ContractsContractIdIndexRoute: typeof ContractsContractIdIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -192,33 +199,40 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsNetworkRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/contracts/$contractId': {
+      id: '/contracts/$contractId'
+      path: '/contracts/$contractId'
+      fullPath: '/contracts/$contractId'
+      preLoaderRoute: typeof ContractsContractIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/contracts/$contractId/': {
       id: '/contracts/$contractId/'
-      path: '/contracts/$contractId'
+      path: '/'
       fullPath: '/contracts/$contractId/'
       preLoaderRoute: typeof ContractsContractIdIndexRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof ContractsContractIdRoute
     }
     '/contracts/$contractId/inspect': {
       id: '/contracts/$contractId/inspect'
-      path: '/contracts/$contractId/inspect'
+      path: '/inspect'
       fullPath: '/contracts/$contractId/inspect'
       preLoaderRoute: typeof ContractsContractIdInspectRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof ContractsContractIdRoute
     }
     '/contracts/$contractId/explorer': {
       id: '/contracts/$contractId/explorer'
-      path: '/contracts/$contractId/explorer'
+      path: '/explorer'
       fullPath: '/contracts/$contractId/explorer'
       preLoaderRoute: typeof ContractsContractIdExplorerRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof ContractsContractIdRoute
     }
     '/contracts/$contractId/discovery': {
       id: '/contracts/$contractId/discovery'
-      path: '/contracts/$contractId/discovery'
+      path: '/discovery'
       fullPath: '/contracts/$contractId/discovery'
       preLoaderRoute: typeof ContractsContractIdDiscoveryRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof ContractsContractIdRoute
     }
     '/contracts/$contractId/inspect/': {
       id: '/contracts/$contractId/inspect/'
@@ -254,15 +268,29 @@ const ContractsContractIdInspectRouteWithChildren =
     ContractsContractIdInspectRouteChildren,
   )
 
-const rootRouteChildren: RootRouteChildren = {
-  IndexRoute: IndexRoute,
-  SdsDemoRoute: SdsDemoRoute,
-  SettingsNetworkRoute: SettingsNetworkRoute,
-  SettingsPreferencesRoute: SettingsPreferencesRoute,
+interface ContractsContractIdRouteChildren {
+  ContractsContractIdDiscoveryRoute: typeof ContractsContractIdDiscoveryRoute
+  ContractsContractIdExplorerRoute: typeof ContractsContractIdExplorerRoute
+  ContractsContractIdInspectRoute: typeof ContractsContractIdInspectRouteWithChildren
+  ContractsContractIdIndexRoute: typeof ContractsContractIdIndexRoute
+}
+
+const ContractsContractIdRouteChildren: ContractsContractIdRouteChildren = {
   ContractsContractIdDiscoveryRoute: ContractsContractIdDiscoveryRoute,
   ContractsContractIdExplorerRoute: ContractsContractIdExplorerRoute,
   ContractsContractIdInspectRoute: ContractsContractIdInspectRouteWithChildren,
   ContractsContractIdIndexRoute: ContractsContractIdIndexRoute,
+}
+
+const ContractsContractIdRouteWithChildren =
+  ContractsContractIdRoute._addFileChildren(ContractsContractIdRouteChildren)
+
+const rootRouteChildren: RootRouteChildren = {
+  IndexRoute: IndexRoute,
+  SdsDemoRoute: SdsDemoRoute,
+  ContractsContractIdRoute: ContractsContractIdRouteWithChildren,
+  SettingsNetworkRoute: SettingsNetworkRoute,
+  SettingsPreferencesRoute: SettingsPreferencesRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/contracts/$contractId.tsx
+++ b/src/routes/contracts/$contractId.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+import { Outlet, createFileRoute } from '@tanstack/react-router'
+import { getStoreState } from '../../store/lensStore'
+
+export const Route = createFileRoute('/contracts/$contractId')({
+  component: ContractLayoutRoute,
+})
+
+
+export function clearActiveContractContext(): void {
+  const state = getStoreState()
+  state.clearActiveContractId()
+  state.clearSelectedKeyPath()
+}
+
+
+export function ContractLayoutRoute() {
+  useEffect(() => {
+    return () => {
+      clearActiveContractContext()
+    }
+  }, [])
+
+  return <Outlet />
+}

--- a/src/test/routes/contractLayoutCleanup.test.ts
+++ b/src/test/routes/contractLayoutCleanup.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { clearActiveContractContext } from '@/routes/contracts/$contractId'
+import { getStoreState, resetStore } from '@/store/lensStore'
+
+const VALID_CONTRACT_ID =
+  'CC42QZWUV2R7PUN2SZZW3Y3A43UUB5L2U3B4K3O5EUT7Y4I2O2W34EWM'
+
+describe('contract layout cleanup (#292)', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
+  it('clears the active contract ID when leaving contract routes', () => {
+    getStoreState().setActiveContractId(VALID_CONTRACT_ID)
+    expect(getStoreState().activeContractId).toBe(VALID_CONTRACT_ID)
+
+    clearActiveContractContext()
+
+    expect(getStoreState().activeContractId).toBe(null)
+  })
+
+  it('clears the selected key path when leaving contract routes', () => {
+    getStoreState().setSelectedKeyPath('entry[0].value')
+    expect(getStoreState().selectedKeyPath).toBe('entry[0].value')
+
+    clearActiveContractContext()
+
+    expect(getStoreState().selectedKeyPath).toBe(null)
+  })
+
+  it('clears both active contract ID and selected key path together', () => {
+    getStoreState().setActiveContractId(VALID_CONTRACT_ID)
+    getStoreState().setSelectedKeyPath('entry[0].value')
+
+    clearActiveContractContext()
+
+    expect(getStoreState().activeContractId).toBe(null)
+    expect(getStoreState().selectedKeyPath).toBe(null)
+  })
+
+  it('is a no-op when context is already empty', () => {
+    clearActiveContractContext()
+
+    expect(getStoreState().activeContractId).toBe(null)
+    expect(getStoreState().selectedKeyPath).toBe(null)
+  })
+
+  it('leaves ledger data untouched (out of scope)', () => {
+    getStoreState().setActiveContractId(VALID_CONTRACT_ID)
+    const ledgerBefore = getStoreState().ledgerData
+
+    clearActiveContractContext()
+
+    expect(getStoreState().ledgerData).toBe(ledgerBefore)
+  })
+})


### PR DESCRIPTION
## Clear active contract context when leaving contract routes

Closes #292

### Problem

Navigating away from a contract route left `activeContractId` and `selectedKeyPath` in the global store, where they could leak into other views. The contract slice already exposed `clearActiveContractId` and `clearSelectedKeyPath`, but nothing called them on route exit because there was no shared layout wrapping the `/contracts/$contractId/*` views.

### Change

Added a layout route at `src/routes/contracts/$contractId.tsx` that wraps all `$contractId` child routes (explorer, inspect, discovery, index). It renders an `<Outlet />` and registers an unmount cleanup that calls the existing clear actions.

The cleanup logic is extracted into a small exported `clearActiveContractContext()` helper so it can be unit-tested without rendering React.

```
routes/contracts/
  $contractId.tsx        ← new layout (sibling of the folder)
  $contractId/
    explorer.tsx
    inspect.tsx
    ...
```

### Why this satisfies the acceptance criteria

- **Leaving contract routes resets context** — the layout unmounts when you navigate out of `/contracts/$contractId/*`, firing the cleanup.
- **Moving between explorer and inspect for the same contract keeps context** — the layout stays mounted across child-route and param changes for the same `contractId`, so cleanup does not run. Param-only changes are handled structurally by the layout's lifecycle rather than manual diffing.
- **Ledger data untouched** — only the active contract ID and selected key path are cleared (there's a test asserting `ledgerData` is unchanged).

### Notes for review

- **"No new route" wording:** this adds a layout route *file*, but introduces no new navigable URL — all existing paths are unchanged; the route tree just re-parents existing children under the layout. A layout was required since there was no existing one to attach the unmount cleanup to.
- **Contract-to-contract switches:** going directly from `/contracts/A/...` to `/contracts/B/...` keeps the same layout instance mounted, so cleanup doesn't fire on that transition — A's context is retained until the explorer's existing `setActiveContractId(B)` effect runs. This matches the issue scope (entering then leaving contract routes) and the verification steps. Happy to add a `contractId`-keyed reset if you'd prefer context to reset on every contract switch too.
- `routeTree.gen.ts` regenerates via the TanStack Router plugin on `vite dev`/`build` — included in the diff.

### Verification

- Entered a contract route and navigated away → `activeContractId` and `selectedKeyPath` cleared.
- Moved between explorer and inspect for the same contract → context preserved.
- `vite build`, `tsc --noEmit`, `eslint`, and `prettier --check` all clean.
- Test suite: 1183 passing (5 new tests in `src/test/routes/contractLayoutCleanup.test.ts`).