### PR TITLE
feat(diff): add semantic diff helper for normalized snapshot entries …

### DIFF
--- a/src/lib/diff/compareNormalizedValuesDeep.ts
+++ b/src/lib/diff/compareNormalizedValuesDeep.ts
@@ -1,0 +1,134 @@
+/**
+ * Performs a deep semantic comparison of two normalized values.
+ *
+ * Comparison rules:
+ * - Primitives use strict equality, with NaN treated as equal to NaN.
+ * - Arrays are compared element-by-element.
+ * - Normalized maps are compared as unordered key/value sets.
+ * - Other objects are compared by their own keys recursively.
+ */
+export function compareNormalizedValuesDeep(
+  a: unknown,
+  b: unknown,
+): boolean {
+  if (a === b) {
+    return true
+  }
+
+  if (typeof a === 'number' && typeof b === 'number') {
+    if (Number.isNaN(a) && Number.isNaN(b)) {
+      return true
+    }
+  }
+
+  if (a === null || b === null || a === undefined || b === undefined) {
+    return a === b
+  }
+
+  if (typeof a !== typeof b) {
+    return false
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      return false
+    }
+    for (let i = 0; i < a.length; i += 1) {
+      if (!compareNormalizedValuesDeep(a[i], b[i])) {
+        return false
+      }
+    }
+    return true
+  }
+
+  if (typeof a === 'object' && typeof b === 'object') {
+    if (Array.isArray(a) || Array.isArray(b)) {
+      return false
+    }
+
+    const mapA = isNormalizedMap(a)
+    const mapB = isNormalizedMap(b)
+
+    if (mapA || mapB) {
+      if (!mapA || !mapB) {
+        return false
+      }
+      return compareNormalizedMapEntries(a.entries, b.entries)
+    }
+
+    const keysA = Object.keys(a as Record<string, unknown>)
+    const keysB = Object.keys(b as Record<string, unknown>)
+
+    if (keysA.length !== keysB.length) {
+      return false
+    }
+
+    for (const key of keysA) {
+      if (!Object.prototype.hasOwnProperty.call(b, key)) {
+        return false
+      }
+      if (
+        !compareNormalizedValuesDeep(
+          (a as Record<string, unknown>)[key],
+          (b as Record<string, unknown>)[key],
+        )
+      ) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  return false
+}
+
+function isNormalizedMap(value: unknown): value is {
+  kind: 'map'
+  entries: Array<{ key: unknown; value: unknown }>
+} {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    (value as Record<string, unknown>).kind === 'map' &&
+    Array.isArray((value as Record<string, unknown>).entries)
+  )
+}
+
+function compareNormalizedMapEntries(
+  entriesA: Array<{ key: unknown; value: unknown }>,
+  entriesB: Array<{ key: unknown; value: unknown }>,
+): boolean {
+  if (entriesA.length !== entriesB.length) {
+    return false
+  }
+
+  const matched = new Array<boolean>(entriesB.length).fill(false)
+
+  for (const entryA of entriesA) {
+    let found = false
+
+    for (let index = 0; index < entriesB.length; index += 1) {
+      if (matched[index]) {
+        continue
+      }
+
+      const entryB = entriesB[index]
+      if (
+        compareNormalizedValuesDeep(entryA.key, entryB.key) &&
+        compareNormalizedValuesDeep(entryA.value, entryB.value)
+      ) {
+        matched[index] = true
+        found = true
+        break
+      }
+    }
+
+    if (!found) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/src/lib/diff/diffSnapshotEntries.ts
+++ b/src/lib/diff/diffSnapshotEntries.ts
@@ -1,0 +1,51 @@
+/**
+ * Represents the diff state of a single ledger snapshot entry.
+ */
+import { compareNormalizedValuesDeep } from './compareNormalizedValuesDeep'
+
+export type SnapshotEntryDiffStatus =
+  | 'created'
+  | 'deleted'
+  | 'modified'
+  | 'unchanged'
+
+export interface SnapshotEntryDiff {
+  key: string
+  status: SnapshotEntryDiffStatus
+  prevEntry?: unknown
+  nextEntry?: unknown
+}
+
+export function diffSnapshotEntries(
+  prevEntries: Record<string, unknown>,
+  nextEntries: Record<string, unknown>,
+): Array<SnapshotEntryDiff> {
+  const diffResults: Array<SnapshotEntryDiff> = []
+  const allKeys = new Set([...Object.keys(prevEntries), ...Object.keys(nextEntries)])
+
+  for (const key of allKeys) {
+    const hasPrev = Object.prototype.hasOwnProperty.call(prevEntries, key)
+    const hasNext = Object.prototype.hasOwnProperty.call(nextEntries, key)
+    const prevEntry = prevEntries[key]
+    const nextEntry = nextEntries[key]
+
+    if (hasPrev && !hasNext) {
+      diffResults.push({ key, status: 'deleted', prevEntry })
+      continue
+    }
+
+    if (!hasPrev && hasNext) {
+      diffResults.push({ key, status: 'created', nextEntry })
+      continue
+    }
+
+    if (compareNormalizedValuesDeep(prevEntry, nextEntry)) {
+      diffResults.push({ key, status: 'unchanged', prevEntry, nextEntry })
+    } else {
+      diffResults.push({ key, status: 'modified', prevEntry, nextEntry })
+    }
+  }
+
+  diffResults.sort((a, b) => a.key.localeCompare(b.key))
+  return diffResults
+}

--- a/src/test/diff/diffSnapshotEntries.test.ts
+++ b/src/test/diff/diffSnapshotEntries.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import { diffSnapshotEntries } from '../../lib/diff/diffSnapshotEntries'
+
+describe('diffSnapshotEntries', () => {
+  it('classifies created entries when only next contains the key', () => {
+    const prevEntries = {}
+    const nextEntries = {
+      'key-1': { kind: 'primitive', primitive: 'u32', value: 1 },
+    }
+
+    const diff = diffSnapshotEntries(prevEntries, nextEntries)
+
+    expect(diff).toEqual([
+      {
+        key: 'key-1',
+        status: 'created',
+        nextEntry: nextEntries['key-1'],
+      },
+    ])
+  })
+
+  it('classifies deleted entries when only prev contains the key', () => {
+    const prevEntries = {
+      'key-1': { kind: 'primitive', primitive: 'u32', value: 1 },
+    }
+    const nextEntries = {}
+
+    const diff = diffSnapshotEntries(prevEntries, nextEntries)
+
+    expect(diff).toEqual([
+      {
+        key: 'key-1',
+        status: 'deleted',
+        prevEntry: prevEntries['key-1'],
+      },
+    ])
+  })
+
+  it('classifies unchanged entries when normalized values are deeply equal', () => {
+    const prevEntries = {
+      'key-1': {
+        kind: 'map',
+        entries: [
+          {
+            key: { kind: 'primitive', primitive: 'string', value: 'a' },
+            value: { kind: 'primitive', primitive: 'u32', value: 1 },
+          },
+        ],
+      },
+    }
+    const nextEntries = {
+      'key-1': {
+        kind: 'map',
+        entries: [
+          {
+            key: { kind: 'primitive', primitive: 'string', value: 'a' },
+            value: { kind: 'primitive', primitive: 'u32', value: 1 },
+          },
+        ],
+      },
+    }
+
+    const diff = diffSnapshotEntries(prevEntries, nextEntries)
+
+    expect(diff).toEqual([
+      {
+        key: 'key-1',
+        status: 'unchanged',
+        prevEntry: prevEntries['key-1'],
+        nextEntry: nextEntries['key-1'],
+      },
+    ])
+  })
+
+  it('classifies modified entries when normalized values differ deeply', () => {
+    const prevEntries = {
+      'key-1': {
+        kind: 'vec',
+        items: [{ kind: 'primitive', primitive: 'u32', value: 1 }],
+      },
+    }
+    const nextEntries = {
+      'key-1': {
+        kind: 'vec',
+        items: [{ kind: 'primitive', primitive: 'u32', value: 2 }],
+      },
+    }
+
+    const diff = diffSnapshotEntries(prevEntries, nextEntries)
+
+    expect(diff).toEqual([
+      {
+        key: 'key-1',
+        status: 'modified',
+        prevEntry: prevEntries['key-1'],
+        nextEntry: nextEntries['key-1'],
+      },
+    ])
+  })
+
+  it('sorts diff results by key name', () => {
+    const prevEntries = {
+      'key-2': { kind: 'primitive', primitive: 'u32', value: 1 },
+      'key-1': { kind: 'primitive', primitive: 'u32', value: 2 },
+    }
+    const nextEntries = {
+      'key-1': { kind: 'primitive', primitive: 'u32', value: 2 },
+      'key-2': { kind: 'primitive', primitive: 'u32', value: 3 },
+    }
+
+    const diff = diffSnapshotEntries(prevEntries, nextEntries)
+
+    expect(diff.map((item) => item.key)).toEqual(['key-1', 'key-2'])
+  })
+})


### PR DESCRIPTION

Summary:
Adds a deep, semantic comparator for decoder-normalized values and a snapshot diff helper that classifies ledger snapshot entries as created / deleted / modified / unchanged. Includes unit tests covering representative cases.




closes #201
closes #204
closes #212