### PR TITLE
Thread maxDepth through worker decodeScVal and add selectSnapshotsFor…

### DIFF
--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -15,6 +15,9 @@ export const selectLedgerEntry = (key: string) => (state: LensStore) =>
 export const selectLedgerEntriesByContract =
   (contractId: string) => (state: LensStore) =>
     Object.values(state.ledgerData).filter((e) => e.contractId === contractId)
+export const selectSnapshotsForContract =
+  (contractId: string) => (state: LensStore) =>
+    state.snapshots[contractId] ?? []
 export const selectLedgerEntryCount = (state: LensStore) =>
   Object.keys(state.ledgerData).length
 export const selectHasLedgerData = (state: LensStore) =>

--- a/src/test/store/selectors.test.ts
+++ b/src/test/store/selectors.test.ts
@@ -21,6 +21,7 @@ import {
   selectNetworkId,
   selectRpcUrl,
   selectSelectedKeyPath,
+  selectSnapshotsForContract,
 } from '../../store/selectors'
 
 import type { LedgerEntry } from '../../store/types'
@@ -97,6 +98,28 @@ describe('selectors', () => {
     it('selectLedgerEntry returns undefined for missing key', () => {
       const entry = selectLedgerEntry('nonexistent')(getStoreState())
       expect(entry).toBeUndefined()
+    })
+
+    it('selectSnapshotsForContract returns snapshots for a contract', () => {
+      const state = getStoreState()
+      state.snapshots['ABC123'] = [
+        {
+          id: 'snapshot-1',
+          contractId: 'ABC123',
+          label: 'Snapshot 1',
+          ledgerData: {},
+          timestamp: 123,
+        },
+      ]
+
+      const snapshots = selectSnapshotsForContract('ABC123')(getStoreState())
+      expect(snapshots).toHaveLength(1)
+      expect(snapshots[0].contractId).toBe('ABC123')
+      expect(snapshots[0].id).toBe('snapshot-1')
+    })
+
+    it('selectSnapshotsForContract returns empty array for unknown contract', () => {
+      expect(selectSnapshotsForContract('UNKNOWN')(getStoreState())).toEqual([])
     })
 
     it('selectLedgerEntriesByContract filters by contractId', () => {

--- a/src/test/workers/decodeScVal.internal.test.ts
+++ b/src/test/workers/decodeScVal.internal.test.ts
@@ -64,6 +64,9 @@ describe('decoderWorkerApi.decodeScVal', () => {
     }
 
     expect(result.kind).toBe('vec')
+    if (result.kind !== 'vec') {
+      throw new Error('expected vec node')
+    }
     expect(result.items).toHaveLength(2)
     expect(result.items[0].kind).toBe('truncated')
     expect(result.items[1].kind).toBe('truncated')

--- a/src/test/workers/decodeScVal.internal.test.ts
+++ b/src/test/workers/decodeScVal.internal.test.ts
@@ -46,4 +46,28 @@ describe('decoderWorkerApi.decodeScVal', () => {
       expect(result.code).toBe('DECODE_FAILED')
     }
   })
+
+  it('should respect maxDepth and truncate nested vec children', async () => {
+    const scVal = xdr.ScVal.scvVec([
+      xdr.ScVal.scvVec([xdr.ScVal.scvI32(1)]),
+      xdr.ScVal.scvVec([xdr.ScVal.scvI32(2)]),
+    ])
+    const xdrString = scVal.toXDR('base64')
+
+    const result = await decoderWorkerApi.decodeScVal({
+      xdr: xdrString,
+      maxDepth: 1,
+    })
+
+    if (isDecoderWorkerError(result)) {
+      throw new Error(`Expected success, got error: ${result.message}`)
+    }
+
+    expect(result.kind).toBe('vec')
+    expect(result.items).toHaveLength(2)
+    expect(result.items[0].kind).toBe('truncated')
+    expect(result.items[1].kind).toBe('truncated')
+    expect(result.items[0].path).toEqual([{ type: 'index', index: 0 }])
+    expect(result.items[1].path).toEqual([{ type: 'index', index: 1 }])
+  })
 })

--- a/src/types/decoder-worker.ts
+++ b/src/types/decoder-worker.ts
@@ -81,6 +81,8 @@ export type NormalizeResult = NormalizeResponse | DecoderWorkerError
 export interface DecodeScValRequest {
   /** Base64 encoded ScVal XDR string */
   xdr: string
+  /** Optional maximum recursion depth for XDR-decoded normalization */
+  maxDepth?: number
 }
 
 /**

--- a/src/workers/decoder.worker.ts
+++ b/src/workers/decoder.worker.ts
@@ -62,7 +62,7 @@ export const decoderWorkerApi: DecoderWorkerApi = {
 
   decodeScVal(request: DecodeScValRequest): Promise<DecodeScValResult> {
     try {
-      const { xdr: xdrString } = request
+      const { xdr: xdrString, maxDepth } = request
 
       // Decode the ScVal from XDR
       const scValXdr = xdr.ScVal.fromXDR(xdrString, 'base64')
@@ -92,8 +92,13 @@ export const decoderWorkerApi: DecoderWorkerApi = {
         value,
       }
 
-      // Perform full node normalization
-      const normalizedNode = normalizeNode(plainScVal)
+      // Perform full node normalization with optional depth limiting
+      const normalizedNode = normalizeNode(
+        plainScVal,
+        undefined,
+        undefined,
+        { maxDepth },
+      )
 
       return Promise.resolve(normalizedNode)
     } catch (error) {


### PR DESCRIPTION
# PR: Thread maxDepth through worker decodeScVal and add selectSnapshotsForContract selector

## Summary
- Extend the decoder worker `decodeScVal` request type to accept an optional `maxDepth` field.
- Forward `maxDepth` into `normalizeNode` during XDR-decoded ScVal normalization.
- Add a regression test ensuring `decodeScVal` returns truncated nodes when `maxDepth` is set.
- Add `selectSnapshotsForContract` selector to the store selectors and tests for known and unknown contracts.

## Validation
- `npm exec -- vitest run src/test/workers/decodeScVal.internal.test.ts`
- `npm exec -- vitest run src/test/store/selectors.test.ts`


Closes #276
Closes #295
Closes #200