### PR TITLE
Add contract watchlist route with tests and fix watchlist selector st…

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsPreferencesRouteImport } from './routes/settings/preferences'
 import { Route as SettingsNetworkRouteImport } from './routes/settings/network'
 import { Route as ContractsContractIdIndexRouteImport } from './routes/contracts/$contractId/index'
+import { Route as ContractsContractIdWatchlistRouteImport } from './routes/contracts/$contractId/watchlist'
 import { Route as ContractsContractIdInspectRouteImport } from './routes/contracts/$contractId/inspect'
 import { Route as ContractsContractIdExplorerRouteImport } from './routes/contracts/$contractId/explorer'
 import { Route as ContractsContractIdDiscoveryRouteImport } from './routes/contracts/$contractId/discovery'
@@ -44,6 +45,12 @@ const ContractsContractIdIndexRoute =
   ContractsContractIdIndexRouteImport.update({
     id: '/contracts/$contractId/',
     path: '/contracts/$contractId/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ContractsContractIdWatchlistRoute =
+  ContractsContractIdWatchlistRouteImport.update({
+    id: '/contracts/$contractId/watchlist',
+    path: '/contracts/$contractId/watchlist',
     getParentRoute: () => rootRouteImport,
   } as any)
 const ContractsContractIdInspectRoute =
@@ -85,6 +92,7 @@ export interface FileRoutesByFullPath {
   '/contracts/$contractId/discovery': typeof ContractsContractIdDiscoveryRoute
   '/contracts/$contractId/explorer': typeof ContractsContractIdExplorerRoute
   '/contracts/$contractId/inspect': typeof ContractsContractIdInspectRouteWithChildren
+  '/contracts/$contractId/watchlist': typeof ContractsContractIdWatchlistRoute
   '/contracts/$contractId/': typeof ContractsContractIdIndexRoute
   '/contracts/$contractId/inspect/$keyPath': typeof ContractsContractIdInspectKeyPathRoute
   '/contracts/$contractId/inspect/': typeof ContractsContractIdInspectIndexRoute
@@ -96,6 +104,7 @@ export interface FileRoutesByTo {
   '/settings/preferences': typeof SettingsPreferencesRoute
   '/contracts/$contractId/discovery': typeof ContractsContractIdDiscoveryRoute
   '/contracts/$contractId/explorer': typeof ContractsContractIdExplorerRoute
+  '/contracts/$contractId/watchlist': typeof ContractsContractIdWatchlistRoute
   '/contracts/$contractId': typeof ContractsContractIdIndexRoute
   '/contracts/$contractId/inspect/$keyPath': typeof ContractsContractIdInspectKeyPathRoute
   '/contracts/$contractId/inspect': typeof ContractsContractIdInspectIndexRoute
@@ -109,6 +118,7 @@ export interface FileRoutesById {
   '/contracts/$contractId/discovery': typeof ContractsContractIdDiscoveryRoute
   '/contracts/$contractId/explorer': typeof ContractsContractIdExplorerRoute
   '/contracts/$contractId/inspect': typeof ContractsContractIdInspectRouteWithChildren
+  '/contracts/$contractId/watchlist': typeof ContractsContractIdWatchlistRoute
   '/contracts/$contractId/': typeof ContractsContractIdIndexRoute
   '/contracts/$contractId/inspect/$keyPath': typeof ContractsContractIdInspectKeyPathRoute
   '/contracts/$contractId/inspect/': typeof ContractsContractIdInspectIndexRoute
@@ -123,6 +133,7 @@ export interface FileRouteTypes {
     | '/contracts/$contractId/discovery'
     | '/contracts/$contractId/explorer'
     | '/contracts/$contractId/inspect'
+    | '/contracts/$contractId/watchlist'
     | '/contracts/$contractId/'
     | '/contracts/$contractId/inspect/$keyPath'
     | '/contracts/$contractId/inspect/'
@@ -134,6 +145,7 @@ export interface FileRouteTypes {
     | '/settings/preferences'
     | '/contracts/$contractId/discovery'
     | '/contracts/$contractId/explorer'
+    | '/contracts/$contractId/watchlist'
     | '/contracts/$contractId'
     | '/contracts/$contractId/inspect/$keyPath'
     | '/contracts/$contractId/inspect'
@@ -146,6 +158,7 @@ export interface FileRouteTypes {
     | '/contracts/$contractId/discovery'
     | '/contracts/$contractId/explorer'
     | '/contracts/$contractId/inspect'
+    | '/contracts/$contractId/watchlist'
     | '/contracts/$contractId/'
     | '/contracts/$contractId/inspect/$keyPath'
     | '/contracts/$contractId/inspect/'
@@ -159,6 +172,7 @@ export interface RootRouteChildren {
   ContractsContractIdDiscoveryRoute: typeof ContractsContractIdDiscoveryRoute
   ContractsContractIdExplorerRoute: typeof ContractsContractIdExplorerRoute
   ContractsContractIdInspectRoute: typeof ContractsContractIdInspectRouteWithChildren
+  ContractsContractIdWatchlistRoute: typeof ContractsContractIdWatchlistRoute
   ContractsContractIdIndexRoute: typeof ContractsContractIdIndexRoute
 }
 
@@ -197,6 +211,13 @@ declare module '@tanstack/react-router' {
       path: '/contracts/$contractId'
       fullPath: '/contracts/$contractId/'
       preLoaderRoute: typeof ContractsContractIdIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/contracts/$contractId/watchlist': {
+      id: '/contracts/$contractId/watchlist'
+      path: '/contracts/$contractId/watchlist'
+      fullPath: '/contracts/$contractId/watchlist'
+      preLoaderRoute: typeof ContractsContractIdWatchlistRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/contracts/$contractId/inspect': {
@@ -262,6 +283,7 @@ const rootRouteChildren: RootRouteChildren = {
   ContractsContractIdDiscoveryRoute: ContractsContractIdDiscoveryRoute,
   ContractsContractIdExplorerRoute: ContractsContractIdExplorerRoute,
   ContractsContractIdInspectRoute: ContractsContractIdInspectRouteWithChildren,
+  ContractsContractIdWatchlistRoute: ContractsContractIdWatchlistRoute,
   ContractsContractIdIndexRoute: ContractsContractIdIndexRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/contracts/$contractId/watchlist.tsx
+++ b/src/routes/contracts/$contractId/watchlist.tsx
@@ -1,0 +1,106 @@
+import { Button, Card, Heading } from '@stellar/design-system'
+import { createFileRoute } from '@tanstack/react-router'
+import { useLensStore, useWatchlist } from '../../../store/lensStore'
+import { validateContractRouteParam } from './-validateContractRouteParam'
+
+export const Route = createFileRoute('/contracts/$contractId/watchlist')({
+  component: WatchlistRoute,
+  beforeLoad: ({ params }) => {
+    const result = validateContractRouteParam(params.contractId)
+    if (!result.ok) {
+      console.error(`Invalid contract ID: ${result.reason}`)
+    }
+
+    return {
+      normalizedContractId: result.ok ? result.contractId : params.contractId,
+    }
+  },
+})
+
+function WatchlistRoute() {
+  const { contractId } = Route.useParams()
+  const { normalizedContractId } = Route.useRouteContext()
+  const navigate = Route.useNavigate()
+  const watchlistItems = useWatchlist(contractId)
+  const removeFromWatchlist = useLensStore((state) => state.removeFromWatchlist)
+
+  const handleInspect = (keyPath: string) => {
+    void navigate({
+      to: '/contracts/$contractId/inspect/$keyPath',
+      params: { contractId, keyPath },
+    })
+  }
+
+  const handleRemove = (keyPath: string) => {
+    removeFromWatchlist(contractId, keyPath)
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6 lg:p-10 max-w-6xl mx-auto w-full">
+      <header className="flex flex-col md:flex-row md:items-end justify-between gap-4 border-b border-border-dark pb-6">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-3">
+            <span className="px-2 py-0.5 rounded bg-primary/20 text-primary text-[10px] font-bold uppercase tracking-wider font-mono">
+              Watchlist
+            </span>
+          </div>
+          <Heading size="lg" as="h1" className="font-mono break-all text-white">
+            {normalizedContractId || contractId}
+          </Heading>
+        </div>
+      </header>
+
+      {watchlistItems.length === 0 ? (
+        <Card>
+          <div className="p-6 space-y-4">
+            <Heading
+              size="sm"
+              as="h2"
+              className="text-white font-bold"
+            >
+              No saved watchlist items
+            </Heading>
+            <p className="text-text-muted text-sm">
+              You do not have any pinned keys for this contract yet.
+              Navigate from discovery or inspect a key to add items to the watchlist.
+            </p>
+          </div>
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {watchlistItems.map((item) => (
+            <Card key={item.keyPath}>
+              <div className="p-4 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div className="min-w-0">
+                  <div className="text-sm font-mono text-white break-all">
+                    {item.keyPath}
+                  </div>
+                  <div className="text-xs text-text-muted mt-1">
+                    Pinned {new Date(item.timestamp).toLocaleString()}
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => handleInspect(item.keyPath)}
+                  >
+                    Inspect
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => handleRemove(item.keyPath)}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/store/lensStore.ts
+++ b/src/store/lensStore.ts
@@ -430,6 +430,8 @@ export const useLensStore = create<LensStore>()(
 /**
  * Selector hooks for common use cases
  */
+const EMPTY_ARRAY: never[] = []
+
 export const useNetworkConfig = () =>
   useLensStore((state) => state.networkConfig)
 export const useLedgerData = () => useLensStore((state) => state.ledgerData)
@@ -444,9 +446,9 @@ export const useContractLoadStatus = () =>
 export const useContractLoadError = () =>
   useLensStore((state) => state.contractLoadError)
 export const useSnapshots = (contractId: string) =>
-  useLensStore((state) => state.snapshots[contractId] ?? [])
+  useLensStore((state) => state.snapshots[contractId] ?? EMPTY_ARRAY)
 export const useWatchlist = (contractId: string) =>
-  useLensStore((state) => state.watchlist[contractId] ?? [])
+  useLensStore((state) => state.watchlist[contractId] ?? EMPTY_ARRAY)
 
 /**
  * Get store state outside of React components (for testing)

--- a/src/test/routes/watchlistRoute.test.tsx
+++ b/src/test/routes/watchlistRoute.test.tsx
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@stellar/design-system', () => ({
+  Button: (props: any) => <button {...props} />,
+  Card: (props: any) => <div {...props}>{props.children}</div>,
+  Heading: (props: any) => <div {...props}>{props.children}</div>,
+}))
+
+import { render, screen } from '@testing-library/react'
+import { createRouter, RouterProvider } from '@tanstack/react-router'
+import { routeTree } from '../../routeTree.gen'
+import { resetStore, useLensStore } from '../../store/lensStore'
+
+const VALID_CONTRACT_ID =
+  'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC'
+
+function createTestRouter() {
+  return createRouter({
+    routeTree,
+    context: {},
+    defaultPreload: 'intent',
+    scrollRestoration: true,
+    defaultStructuralSharing: true,
+    defaultPreloadStaleTime: 0,
+  })
+}
+
+describe('Watchlist route', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
+  it('renders an empty state when no watchlist items exist for the contract', async () => {
+    window.history.pushState({}, '', `/contracts/${VALID_CONTRACT_ID}/watchlist`)
+
+    const router = createTestRouter()
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByText('No saved watchlist items')).toBeTruthy()
+    expect(
+      screen.getByText(/You do not have any pinned keys for this contract yet/),
+    ).toBeTruthy()
+  })
+
+  it('renders saved watchlist items and an inspect action', async () => {
+    useLensStore.getState().addToWatchlist(VALID_CONTRACT_ID, '/test/key')
+    window.history.pushState({}, '', `/contracts/${VALID_CONTRACT_ID}/watchlist`)
+
+    const router = createTestRouter()
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByText('/test/key')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Inspect' })).toBeTruthy()
+  })
+})


### PR DESCRIPTION
# Pull Request: Add Contract Watchlist Route

## Summary
- Added a new route for contract-specific watchlists at `/contracts/:contractId/watchlist`.
- Implemented an empty state for contracts with no saved watchlist items.
- Added saved watchlist item cards with `Inspect` and `Remove` actions.
- Preserved route parameter validation and normalized contract IDs using the existing route-level validator.

## Files Changed
- `src/routes/contracts/$contractId/watchlist.tsx`
- `src/test/routes/watchlistRoute.test.tsx`
- `src/store/lensStore.ts`
- `src/routeTree.gen.ts`

## Notes
- Fixed a React selector stability issue by returning a constant empty array from `useWatchlist` and `useSnapshots` when no data exists.
- The watchlist state remains non-persistent as intended.

## Validation
- Full test suite passed: `101` files, `1180` tests
- Branch pushed to `origin/feature/watchlist-route`


CLOSES #215
Closes #203
Closes #208
Closes #195