### PR TITLE
feat: normalize read/write footprint keys from simulation results

### DIFF
--- a/src/lib/network/normalizeFootprintKeys.ts
+++ b/src/lib/network/normalizeFootprintKeys.ts
@@ -1,0 +1,92 @@
+/**
+ * Footprint key normalization for Soroban State Lens.
+ *
+ * Turns a simulation result's footprint into a list of candidate discovery
+ * keys. Where {@link extractFootprintKeys} performs a lightweight extraction of
+ * the raw read/write string arrays, this module operates on the typed
+ * simulation result and normalizes every key into one stable identity shape so
+ * downstream discovery code can treat read and write keys uniformly.
+ */
+
+import type { SimulateTransactionResult } from './simulateTransaction'
+
+/** Whether a footprint key belongs to the read-only or read-write section. */
+export type FootprintAccess = 'read' | 'write'
+
+/** A footprint ledger key normalized into one stable identity shape. */
+export interface FootprintKey {
+  /** Stable identity of the ledger key (its base64-encoded XDR string). */
+  id: string
+  /** Whether the key was found in the read-only or read-write footprint. */
+  access: FootprintAccess
+}
+
+/** Candidate discovery keys derived from a simulation footprint. */
+export interface NormalizedFootprint {
+  /** Deduplicated, lexically ordered read-only keys. */
+  readOnly: Array<string>
+  /** Deduplicated, lexically ordered read-write keys. */
+  readWrite: Array<string>
+  /**
+   * Flat, deduplicated, ordered list of every candidate key with its access
+   * classification. Read keys come first (ordered), followed by write keys
+   * (ordered). A key present in both footprint sections is reported once as
+   * `write`, since write access implies read access.
+   */
+  keys: Array<FootprintKey>
+}
+
+/**
+ * Extracts and normalizes read and write footprint keys from a simulation
+ * result.
+ *
+ * Keys are trimmed, blank entries are dropped, duplicates are removed both
+ * within and across the read/write sections, and the output is returned in a
+ * predictable, lexically sorted order.
+ *
+ * @param result A simulation result, or null/undefined for none.
+ * @returns Normalized read/write keys plus a unified, classified key list.
+ */
+export function normalizeFootprintKeys(
+  result: SimulateTransactionResult | null | undefined,
+): NormalizedFootprint {
+  const footprint = result?.success ? result.footprint : undefined
+  if (!footprint) {
+    return { readOnly: [], readWrite: [], keys: [] }
+  }
+
+  const readOnly = normalizeSection(footprint.readOnly)
+  const readWrite = normalizeSection(footprint.readWrite)
+
+  const writeSet = new Set(readWrite)
+  const keys: Array<FootprintKey> = [
+    ...readOnly
+      .filter((id) => !writeSet.has(id))
+      .map((id): FootprintKey => ({ id, access: 'read' })),
+    ...readWrite.map((id): FootprintKey => ({ id, access: 'write' })),
+  ]
+
+  return { readOnly, readWrite, keys }
+}
+
+/**
+ * Trims, drops blanks, deduplicates, and lexically sorts a footprint section.
+ */
+function normalizeSection(section: Array<string> | undefined): Array<string> {
+  if (!section) {
+    return []
+  }
+
+  const seen = new Set<string>()
+  for (const raw of section) {
+    if (typeof raw !== 'string') {
+      continue
+    }
+    const id = raw.trim()
+    if (id !== '') {
+      seen.add(id)
+    }
+  }
+
+  return [...seen].sort()
+}

--- a/src/test/network/normalizeFootprintKeys.test.ts
+++ b/src/test/network/normalizeFootprintKeys.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeFootprintKeys } from '../../lib/network/normalizeFootprintKeys'
+import type { SimulateTransactionResult } from '../../lib/network/simulateTransaction'
+
+function success(
+  footprint: { readOnly?: Array<string>; readWrite?: Array<string> },
+): SimulateTransactionResult {
+  return {
+    success: true,
+    footprint: {
+      readOnly: footprint.readOnly ?? [],
+      readWrite: footprint.readWrite ?? [],
+    },
+  }
+}
+
+describe('normalizeFootprintKeys', () => {
+  it('returns empty shape when result is null', () => {
+    expect(normalizeFootprintKeys(null)).toEqual({
+      readOnly: [],
+      readWrite: [],
+      keys: [],
+    })
+  })
+
+  it('returns empty shape when result is undefined', () => {
+    expect(normalizeFootprintKeys(undefined)).toEqual({
+      readOnly: [],
+      readWrite: [],
+      keys: [],
+    })
+  })
+
+  it('returns empty shape for an unsuccessful result', () => {
+    const result = normalizeFootprintKeys({
+      success: false,
+      error: 'simulation failed',
+    })
+    expect(result).toEqual({ readOnly: [], readWrite: [], keys: [] })
+  })
+
+  it('returns empty shape when the footprint is missing', () => {
+    const result = normalizeFootprintKeys({ success: true })
+    expect(result).toEqual({ readOnly: [], readWrite: [], keys: [] })
+  })
+
+  describe('read-only payloads', () => {
+    it('extracts and orders read-only keys', () => {
+      const result = normalizeFootprintKeys(
+        success({ readOnly: ['zzz', 'aaa', 'mmm'] }),
+      )
+      expect(result.readOnly).toEqual(['aaa', 'mmm', 'zzz'])
+      expect(result.readWrite).toEqual([])
+      expect(result.keys).toEqual([
+        { id: 'aaa', access: 'read' },
+        { id: 'mmm', access: 'read' },
+        { id: 'zzz', access: 'read' },
+      ])
+    })
+
+    it('deduplicates repeated read-only keys', () => {
+      const result = normalizeFootprintKeys(
+        success({ readOnly: ['key1', 'key2', 'key1', 'key2', 'key1'] }),
+      )
+      expect(result.readOnly).toEqual(['key1', 'key2'])
+      expect(result.keys).toEqual([
+        { id: 'key1', access: 'read' },
+        { id: 'key2', access: 'read' },
+      ])
+    })
+  })
+
+  describe('write-only payloads', () => {
+    it('extracts and orders read-write keys', () => {
+      const result = normalizeFootprintKeys(
+        success({ readWrite: ['ccc', 'aaa', 'bbb'] }),
+      )
+      expect(result.readOnly).toEqual([])
+      expect(result.readWrite).toEqual(['aaa', 'bbb', 'ccc'])
+      expect(result.keys).toEqual([
+        { id: 'aaa', access: 'write' },
+        { id: 'bbb', access: 'write' },
+        { id: 'ccc', access: 'write' },
+      ])
+    })
+
+    it('deduplicates repeated read-write keys', () => {
+      const result = normalizeFootprintKeys(
+        success({ readWrite: ['keyA', 'keyB', 'keyA'] }),
+      )
+      expect(result.readWrite).toEqual(['keyA', 'keyB'])
+    })
+  })
+
+  describe('mixed payloads', () => {
+    it('lists read keys before write keys, each ordered', () => {
+      const result = normalizeFootprintKeys(
+        success({ readOnly: ['r2', 'r1'], readWrite: ['w2', 'w1'] }),
+      )
+      expect(result.readOnly).toEqual(['r1', 'r2'])
+      expect(result.readWrite).toEqual(['w1', 'w2'])
+      expect(result.keys).toEqual([
+        { id: 'r1', access: 'read' },
+        { id: 'r2', access: 'read' },
+        { id: 'w1', access: 'write' },
+        { id: 'w2', access: 'write' },
+      ])
+    })
+
+    it('reports a key in both sections once as write in the flat list', () => {
+      const result = normalizeFootprintKeys(
+        success({ readOnly: ['shared', 'readish'], readWrite: ['shared'] }),
+      )
+      // Sections retain their own membership.
+      expect(result.readOnly).toEqual(['readish', 'shared'])
+      expect(result.readWrite).toEqual(['shared'])
+      // The unified list dedupes across sections, preferring write access.
+      expect(result.keys).toEqual([
+        { id: 'readish', access: 'read' },
+        { id: 'shared', access: 'write' },
+      ])
+    })
+  })
+
+  describe('normalization', () => {
+    it('trims whitespace before deduping', () => {
+      const result = normalizeFootprintKeys(
+        success({ readOnly: [' key1', 'key1 ', 'key1'] }),
+      )
+      expect(result.readOnly).toEqual(['key1'])
+    })
+
+    it('drops blank and whitespace-only keys', () => {
+      const result = normalizeFootprintKeys(
+        success({ readOnly: ['', '   ', 'key1'], readWrite: [''] }),
+      )
+      expect(result.readOnly).toEqual(['key1'])
+      expect(result.readWrite).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
closes #207

## What
Adds `normalizeFootprintKeys`, which turns a `SimulateTransactionResult` footprint
into a list of candidate discovery keys normalized into one stable identity shape.

This builds on the lightweight string-array extraction added in #31 without
modifying it: where `extractFootprintKeys` handles raw read/write string arrays,
the new function operates on the typed simulation result and produces a unified,
classified key list for downstream discovery.

## Changes
- `src/lib/network/normalizeFootprintKeys.ts`
  - Parses the read-only and read-write footprint sections from a successful
    simulation result.
  - Normalizes each key: trims whitespace, drops blank/whitespace-only entries.
  - Dedupes keys both within each section and across sections.
  - Returns `readOnly` and `readWrite` arrays plus a flat `keys` list of
    `{ id, access }` records in a predictable order: read keys first (sorted),
    then write keys (sorted).
  - A key present in both sections appears once in the flat list as `write`,
    since write access implies read access.
  - Returns an empty shape for null/undefined, unsuccessful, or footprint-less
    results.
- `src/test/network/normalizeFootprintKeys.test.ts`
  - Tests for read-only, write-only, mixed, and duplicate-key payloads, plus
    null/unsuccessful/missing-footprint and trimming/blank normalization.

## Acceptance criteria
- Read and write footprint keys are extracted correctly.
- Keys are deduped and returned in a predictable order and shape.

## Verification
- New tests: 13 passing.
- Full suite: 1190 passing (101 files), no regressions.
- ESLint and `tsc --noEmit` clean.

## Scope
- No watchlist integration.
- No automatic fetch of discovered keys.
