### PR TITLE
Honor caller AbortSignal in callRpc

### DIFF
--- a/src/lib/network/rpcClient.ts
+++ b/src/lib/network/rpcClient.ts
@@ -1,11 +1,43 @@
 import type { RpcConfig, RpcError } from './types'
 
+function isAbortError(error: unknown): boolean {
+  if (error instanceof Error && error.name === 'AbortError') {
+    return true
+  }
+  if (
+    typeof DOMException !== 'undefined' &&
+    error instanceof DOMException &&
+    error.name === 'AbortError'
+  ) {
+    return true
+  }
+  return false
+}
+
 export async function callRpc<T = unknown>(
   config: RpcConfig,
   body?: unknown,
 ): Promise<T | RpcError> {
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), config.timeout)
+
+  // Link an optional caller-provided signal so route changes can abort
+  // in-flight RPC calls. The internal timeout controller still drives the
+  // fetch signal; the caller signal only fans its abort into that controller.
+  let callerAborted = false
+  const callerSignal = config.signal
+  const onCallerAbort = () => {
+    callerAborted = true
+    controller.abort()
+  }
+  if (callerSignal) {
+    if (callerSignal.aborted) {
+      callerAborted = true
+      controller.abort()
+    } else {
+      callerSignal.addEventListener('abort', onCallerAbort, { once: true })
+    }
+  }
 
   try {
     const response = await fetch(config.url, {
@@ -35,10 +67,15 @@ export async function callRpc<T = unknown>(
   } catch (error) {
     clearTimeout(timeoutId)
 
-    if (
-      (error instanceof Error && error.name === 'AbortError') ||
-      (error instanceof DOMException && error.name === 'AbortError')
-    ) {
+    if (isAbortError(error)) {
+      if (callerAborted) {
+        return {
+          message: 'Request aborted',
+          code: 'ABORTED',
+          details: 'Caller aborted the request',
+          isTimeout: false,
+        }
+      }
       return {
         message: 'Request timeout',
         code: 'TIMEOUT',
@@ -61,6 +98,10 @@ export async function callRpc<T = unknown>(
       code: 'UNKNOWN_ERROR',
       details: error,
       isTimeout: false,
+    }
+  } finally {
+    if (callerSignal) {
+      callerSignal.removeEventListener('abort', onCallerAbort)
     }
   }
 }

--- a/src/lib/network/types.ts
+++ b/src/lib/network/types.ts
@@ -2,6 +2,11 @@ export interface RpcConfig {
   url: string
   timeout: number
   headers?: Record<string, string>
+  /**
+   * Optional caller-provided signal. When aborted, the in-flight request is
+   * cancelled and callRpc resolves with a stable `ABORTED` error shape.
+   */
+  signal?: AbortSignal
 }
 
 export interface RpcError {

--- a/src/test/network/rpcClient.test.ts
+++ b/src/test/network/rpcClient.test.ts
@@ -132,6 +132,68 @@ describe('callRpc', () => {
     })
   })
 
+  it('aborts the in-flight request when a caller signal aborts', async () => {
+    const caller = new AbortController()
+    mockFetch.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          caller.signal.addEventListener('abort', () =>
+            reject(new DOMException('The operation was aborted.', 'AbortError')),
+          )
+        }),
+    )
+
+    const abortPromise = callRpc(
+      { ...defaultConfig, signal: caller.signal },
+      { method: 'test' },
+    )
+    caller.abort()
+    const result = await abortPromise
+
+    expect(result).toMatchObject({
+      message: 'Request aborted',
+      code: 'ABORTED',
+      isTimeout: false,
+    })
+  })
+
+  it('returns an aborted shape when the caller signal is already aborted', async () => {
+    const caller = new AbortController()
+    caller.abort()
+    mockFetch.mockImplementationOnce(
+      () =>
+        Promise.reject(
+          new DOMException('The operation was aborted.', 'AbortError'),
+        ),
+    )
+
+    const result = await callRpc(
+      { ...defaultConfig, signal: caller.signal },
+      { method: 'test' },
+    )
+
+    expect(result).toMatchObject({
+      message: 'Request aborted',
+      code: 'ABORTED',
+      isTimeout: false,
+    })
+  })
+
+  it('still uses the internal timeout when no caller signal is provided', async () => {
+    mockFetch.mockRejectedValueOnce(
+      new DOMException('The operation was aborted.', 'AbortError'),
+    )
+
+    const result = await callRpc({ ...defaultConfig, timeout: 1000 })
+
+    expect(result).toMatchObject({
+      message: 'Request timeout',
+      code: 'TIMEOUT',
+      details: 'Request timed out after 1000ms',
+      isTimeout: true,
+    })
+  })
+
   it('should handle JSON parsing errors', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,


### PR DESCRIPTION
Allow callers to pass an AbortSignal via RpcConfig; aborting it cancels the in-flight fetch with a stable ABORTED error shape. The internal timeout still applies when no caller signal is supplied. Closes #287