### PR TITLE
Add simulateTransaction request helper

### DIFF
--- a/src/lib/network/simulateTransaction.ts
+++ b/src/lib/network/simulateTransaction.ts
@@ -99,7 +99,10 @@ export async function simulateTransaction(
       signal,
     })
   } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
+    // Detect aborts by the canonical `name` rather than `instanceof Error`,
+    // since DOMException is not an Error subclass and fetch implementations
+    // surface aborts as DOMException('AbortError') / plain objects.
+    if (error != null && typeof error === 'object' && 'name' in error && (error as { name: unknown }).name === 'AbortError') {
       return { success: false, error: 'Request aborted' }
     }
     return {

--- a/src/lib/network/simulateTransaction.ts
+++ b/src/lib/network/simulateTransaction.ts
@@ -3,6 +3,18 @@
  * Translates simulation responses into reusable discovery data
  */
 
+import { buildJsonRpcRequest } from '../rpc/buildJsonRpcRequest'
+import { isJsonRpcErrorResponse } from '../rpc/isJsonRpcErrorResponse'
+import { isJsonRpcSuccessResponse } from '../rpc/isJsonRpcSuccessResponse'
+import { toRpcRequestId } from '../rpc/toRpcRequestId'
+
+export interface SimulateTransactionParams {
+  rpcUrl: string
+  /** Base64 transaction envelope XDR to simulate. */
+  transaction: string
+  signal?: AbortSignal
+}
+
 export interface SimulateTransactionResponse {
   results?: Array<{
     auth?: Array<unknown>
@@ -53,4 +65,77 @@ export function simulateTransactionAdapter(
       readWrite: response.footprint?.readWrite ?? [],
     },
   }
+}
+
+/**
+ * Sends a `simulateTransaction` JSON-RPC request and returns a normalized
+ * result shape. Request failures (HTTP errors, JSON-RPC errors, malformed
+ * payloads, and aborts) are surfaced as handled {@link SimulateTransactionResult}
+ * values instead of thrown exceptions, so callers can branch on `success`
+ * without try/catch.
+ */
+export async function simulateTransaction(
+  params: SimulateTransactionParams,
+): Promise<SimulateTransactionResult> {
+  const { rpcUrl, transaction, signal } = params
+
+  if (!transaction) {
+    return { success: false, error: 'Transaction XDR is required' }
+  }
+
+  const requestId = toRpcRequestId()
+  const payload = buildJsonRpcRequest(
+    'simulateTransaction',
+    { transaction },
+    requestId,
+  )
+
+  let response: Response
+  try {
+    response = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal,
+    })
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      return { success: false, error: 'Request aborted' }
+    }
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Network error',
+    }
+  }
+
+  if (!response.ok) {
+    return {
+      success: false,
+      error: `HTTP ${response.status}: ${response.statusText}`,
+    }
+  }
+
+  let data: unknown
+  try {
+    data = await response.json()
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Invalid JSON response',
+    }
+  }
+
+  if (isJsonRpcErrorResponse(data)) {
+    return {
+      success: false,
+      error: `RPC Error (${data.error.code}): ${data.error.message}`,
+    }
+  }
+
+  if (!isJsonRpcSuccessResponse(data)) {
+    return { success: false, error: 'Invalid JSON-RPC response format' }
+  }
+
+  const result = data.result as SimulateTransactionResponse | undefined
+  return simulateTransactionAdapter(result ?? null)
 }

--- a/src/test/network/simulateTransaction.test.ts
+++ b/src/test/network/simulateTransaction.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest'
-import { simulateTransactionAdapter } from '../../lib/network/simulateTransaction'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  simulateTransaction,
+  simulateTransactionAdapter,
+} from '../../lib/network/simulateTransaction'
 import { extractFootprintKeys } from '../../lib/network/footprint'
 
 describe('simulateTransactionAdapter', () => {
@@ -102,5 +105,143 @@ describe('extractFootprintKeys', () => {
     const result2 = extractFootprintKeys({ readWrite: ['key1'] })
     expect(result2.readOnly).toEqual([])
     expect(result2.readWrite).toEqual(['key1'])
+  })
+})
+
+describe('simulateTransaction request helper', () => {
+  const mockRpcUrl = 'https://test.rpc.url'
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('returns a parsed success response', async () => {
+    const rpcResponse = {
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        latestLedger: 100,
+        results: [{ xdr: 'some-xdr', auth: [] }],
+        footprint: {
+          readOnly: ['key1'],
+          readWrite: ['key2'],
+        },
+      },
+    }
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => rpcResponse,
+    } as Response)
+
+    const result = await simulateTransaction({
+      rpcUrl: mockRpcUrl,
+      transaction: 'base64-xdr',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.latestLedger).toBe(100)
+    expect(result.results).toHaveLength(1)
+    expect(result.footprint?.readOnly).toEqual(['key1'])
+    expect(result.footprint?.readWrite).toEqual(['key2'])
+    expect(fetch).toHaveBeenCalledWith(
+      mockRpcUrl,
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  })
+
+  it('returns a handled error on JSON-RPC error', async () => {
+    const rpcResponse = {
+      jsonrpc: '2.0',
+      id: 1,
+      error: { code: -32602, message: 'Invalid params' },
+    }
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => rpcResponse,
+    } as Response)
+
+    const result = await simulateTransaction({
+      rpcUrl: mockRpcUrl,
+      transaction: 'base64-xdr',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('RPC Error')
+  })
+
+  it('returns a handled error on HTTP failure', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    } as Response)
+
+    const result = await simulateTransaction({
+      rpcUrl: mockRpcUrl,
+      transaction: 'base64-xdr',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('HTTP 500')
+  })
+
+  it('returns a handled error on malformed JSON-RPC', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ not: 'rpc' }),
+    } as Response)
+
+    const result = await simulateTransaction({
+      rpcUrl: mockRpcUrl,
+      transaction: 'base64-xdr',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Invalid JSON-RPC')
+  })
+
+  it('returns a handled error when the transaction XDR is empty', async () => {
+    const result = await simulateTransaction({
+      rpcUrl: mockRpcUrl,
+      transaction: '',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('required')
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns a handled abort error when the caller signal is aborted', async () => {
+    vi.mocked(fetch).mockRejectedValue(
+      new DOMException('The operation was aborted.', 'AbortError'),
+    )
+
+    const result = await simulateTransaction({
+      rpcUrl: mockRpcUrl,
+      transaction: 'base64-xdr',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('Request aborted')
+  })
+
+  it('returns a handled error on network failure', async () => {
+    vi.mocked(fetch).mockRejectedValue(new TypeError('Failed to fetch'))
+
+    const result = await simulateTransaction({
+      rpcUrl: mockRpcUrl,
+      transaction: 'base64-xdr',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('Failed to fetch')
   })
 })


### PR DESCRIPTION
Adds a simulateTransaction JSON-RPC request helper that returns a stable parsed result shape. HTTP, JSON-RPC, malformed-payload, abort, and network failures are normalized to handled error results instead of untyped crashes. Closes #206