### PR TITLE
Render inspector breadcrumb from contract and key path

### DIFF
--- a/src/components/explorer/InspectShell.tsx
+++ b/src/components/explorer/InspectShell.tsx
@@ -1,5 +1,6 @@
 import { Button, Card, Heading, IconButton } from '@stellar/design-system'
 import { useLensStore } from '../../store/lensStore'
+import { buildInspectBreadcrumb } from './buildInspectBreadcrumb'
 
 interface InspectShellProps {
   contractId: string
@@ -39,6 +40,8 @@ export function InspectShell({
     navigator.clipboard.writeText(mockXDR)
   }
 
+  const breadcrumb = buildInspectBreadcrumb(contractId, keyPath)
+
   return (
     <div className="flex flex-col gap-6 p-6 lg:p-10 max-w-6xl mx-auto w-full">
       <header className="flex flex-col md:flex-row md:items-end justify-between gap-4 border-b border-border-dark pb-6">
@@ -63,11 +66,34 @@ export function InspectShell({
         </div>
       </header>
 
-      <div className="flex items-center gap-2 text-sm text-text-muted font-mono">
-        <span>Contract</span>
-        <span>/</span>
-        <span className="text-white truncate">{keyPath || 'No key selected'}</span>
-      </div>
+      <nav
+        aria-label="Inspect breadcrumb"
+        className="flex flex-wrap items-center gap-1 text-sm text-text-muted font-mono overflow-hidden"
+      >
+        {breadcrumb.segments.map((segment, index) => {
+          const isLast = index === breadcrumb.segments.length - 1
+          return (
+            <span
+              key={`${index}-${segment.label}`}
+              className="flex items-center gap-1 min-w-0"
+            >
+              <span
+                title={segment.title ?? segment.label}
+                className={
+                  isLast
+                    ? 'text-white truncate max-w-[16rem]'
+                    : 'text-text-muted truncate max-w-[12rem]'
+                }
+              >
+                {segment.label}
+              </span>
+              {!isLast ? (
+                <span className="text-text-muted shrink-0">/</span>
+              ) : null}
+            </span>
+          )
+        })}
+      </nav>
 
       {keyPathError ? (
         <Card>

--- a/src/components/explorer/buildInspectBreadcrumb.ts
+++ b/src/components/explorer/buildInspectBreadcrumb.ts
@@ -1,0 +1,63 @@
+import { parseTreeNodePath } from '../../lib/tree/parseTreeNodePath'
+import { formatContractIdShort } from '../../lib/format/formatContractIdShort'
+
+export interface BreadcrumbSegment {
+  /** Display label for the breadcrumb segment. */
+  label: string
+  /** Title attribute / full value for tooltips on truncated segments. */
+  title?: string
+}
+
+export interface InspectBreadcrumb {
+  segments: Array<BreadcrumbSegment>
+}
+
+/**
+ * Maximum number of characters shown for a key-path segment before it is
+ * middle-truncated. Long Soroban key paths (e.g. nested map keys encoded as
+ * base64) would otherwise blow out the breadcrumb width and wrap awkwardly.
+ */
+const MAX_SEGMENT_LENGTH = 24
+
+function truncateSegment(value: string): BreadcrumbSegment {
+  if (value.length <= MAX_SEGMENT_LENGTH) {
+    return { label: value }
+  }
+  const head = value.slice(0, 11)
+  const tail = value.slice(value.length - 8)
+  return { label: `${head}…${tail}`, title: value }
+}
+
+/**
+ * Builds a breadcrumb trail for the inspect header from the contract ID and
+ * the dot-joined escaped key path. The contract ID is shortened for display
+ * while the full value is surfaced as a tooltip; key-path segments are
+ * parsed with the shared tree path parser so escapes round-trip correctly.
+ */
+export function buildInspectBreadcrumb(
+  contractId: string,
+  keyPath: string,
+): InspectBreadcrumb {
+  const contractLabel = formatContractIdShort(contractId)
+  const contractSegment: BreadcrumbSegment =
+    contractLabel === '-'
+      ? { label: 'Contract' }
+      : { label: contractLabel, title: contractId || undefined }
+
+  const keySegments = parseTreeNodePath(keyPath)
+
+  // An empty path or a clearly invalid path (trailing backslash) parses to
+  // an empty array — show a neutral "Root" segment so the trail is never blank.
+  if (keySegments.length === 0) {
+    return {
+      segments: [contractSegment, { label: keyPath ? 'Root' : 'No key' }],
+    }
+  }
+
+  return {
+    segments: [
+      contractSegment,
+      ...keySegments.map((segment) => truncateSegment(segment)),
+    ],
+  }
+}

--- a/src/test/components/buildInspectBreadcrumb.test.ts
+++ b/src/test/components/buildInspectBreadcrumb.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { buildInspectBreadcrumb } from '../../components/explorer/buildInspectBreadcrumb'
+
+describe('buildInspectBreadcrumb', () => {
+  const contractId = 'CDR3Q7WWNW7UKCR2O5JTD3NT2XZCOWHUZYEYO5DUOWDRYZ7P7XN25QJD'
+
+  it('shortens the contract id and parses a single key segment', () => {
+    const { segments } = buildInspectBreadcrumb(contractId, 'counter')
+    expect(segments).toHaveLength(2)
+    expect(segments[0].label).toBe('CDR3Q7...5QJD')
+    expect(segments[0].title).toBe(contractId)
+    expect(segments[1]).toEqual({ label: 'counter' })
+  })
+
+  it('parses a dotted key path into ordered segments', () => {
+    const { segments } = buildInspectBreadcrumb(
+      contractId,
+      'admin.address',
+    )
+    expect(segments.map((s) => s.label)).toEqual([
+      'CDR3Q7...5QJD',
+      'admin',
+      'address',
+    ])
+  })
+
+  it('honours escaped dots in the key path', () => {
+    const { segments } = buildInspectBreadcrumb(contractId, 'a\\.b.c')
+    expect(segments.map((s) => s.label)).toEqual([
+      'CDR3Q7...5QJD',
+      'a.b',
+      'c',
+    ])
+  })
+
+  it('middle-truncates very long segments and keeps the full value as title', () => {
+    const longKey = 'z'.repeat(60)
+    const { segments } = buildInspectBreadcrumb(contractId, longKey)
+    expect(segments).toHaveLength(2)
+    expect(segments[1].label.length).toBeLessThan(longKey.length)
+    expect(segments[1].label).toContain('…')
+    expect(segments[1].title).toBe(longKey)
+  })
+
+  it('falls back to a Root segment for an invalid path', () => {
+    const { segments } = buildInspectBreadcrumb(contractId, 'trailing\\')
+    expect(segments.map((s) => s.label)).toEqual(['CDR3Q7...5QJD', 'Root'])
+  })
+
+  it('shows a No key segment when the path is empty', () => {
+    const { segments } = buildInspectBreadcrumb(contractId, '')
+    expect(segments.map((s) => s.label)).toEqual(['CDR3Q7...5QJD', 'No key'])
+  })
+
+  it('renders a neutral contract label when the contract id is blank', () => {
+    const { segments } = buildInspectBreadcrumb('', 'counter')
+    expect(segments[0].label).toBe('Contract')
+    expect(segments[1].label).toBe('counter')
+  })
+})


### PR DESCRIPTION
Builds a breadcrumb trail in the inspect header from the contract ID and the dot-joined key path. Segments are parsed with the shared tree path parser so escaped dots round-trip correctly, long segments are middle-truncated with the full value surfaced as a tooltip, and empty/invalid paths fall back to a neutral segment. Closes #193