### PR TITLE
Add back-to-explorer link in inspect view

### DIFF
--- a/src/components/explorer/InspectShell.tsx
+++ b/src/components/explorer/InspectShell.tsx
@@ -1,4 +1,5 @@
 import { Button, Card, Heading, IconButton } from '@stellar/design-system'
+import { Link } from '@tanstack/react-router'
 import { useLensStore } from '../../store/lensStore'
 
 interface InspectShellProps {
@@ -53,6 +54,15 @@ export function InspectShell({
           </Heading>
         </div>
         <div className="flex items-center gap-2 shrink-0">
+          <Link
+            to="/contracts/$contractId/explorer"
+            params={{ contractId }}
+            search={{ keys: '' }}
+            aria-label="Back to explorer"
+            className="text-sm text-primary hover:underline font-mono whitespace-nowrap"
+          >
+            ← Explorer
+          </Link>
           <IconButton
             icon="pin"
             altText="Add to watchlist"


### PR DESCRIPTION
Adds a back control in the inspect header that routes to the explorer for the active contract, preserving the contract ID. The pin action and existing header layout are unchanged. Closes #298