### PR TITLE
Apply withRpcRetries to getLedgerEntries and guard empty keys

### DIFF
--- a/src/lib/network/getLedgerEntries.ts
+++ b/src/lib/network/getLedgerEntries.ts
@@ -2,6 +2,7 @@ import { buildJsonRpcRequest } from '../rpc/buildJsonRpcRequest'
 import { isJsonRpcErrorResponse } from '../rpc/isJsonRpcErrorResponse'
 import { isJsonRpcSuccessResponse } from '../rpc/isJsonRpcSuccessResponse'
 import { toRpcRequestId } from '../rpc/toRpcRequestId'
+import { withRpcRetries } from '../rpc/withRpcRetries'
 
 export interface GetLedgerEntriesParams {
   rpcUrl: string
@@ -29,8 +30,32 @@ export class AbortError extends Error {
 }
 
 /**
+ * Normalized error shape returned by the retry-wrapped operation so
+ * {@link withRpcRetries} can classify transient failures (429, 5xx, JSON-RPC
+ * transient codes) against the shared retry policy before re-surfacing them.
+ */
+interface LedgerEntriesRpcError {
+  message: string
+  /** HTTP status for HTTP failures, or JSON-RPC error code. */
+  code?: string | number
+  /** HTTP status mirrored for the retry classifier. */
+  status?: number
+  details?: string
+}
+
+type LedgerEntriesOpResult = GetLedgerEntriesResult | LedgerEntriesRpcError
+
+function isRpcError(
+  value: LedgerEntriesOpResult,
+): value is LedgerEntriesRpcError {
+  return !('entries' in value)
+}
+
+/**
  * Fetches ledger entries for the given keys using a raw JSON-RPC request.
- * Honors the provided AbortSignal for cancellation.
+ * Honors the provided AbortSignal for cancellation and routes the network
+ * call through the shared {@link withRpcRetries} retry policy so transient
+ * 429 and 5xx failures are retried up to the configured cap.
  *
  * @param params - RPC URL, array of base64 ledger keys, and optional AbortSignal.
  * @returns Parsed ledger entries and latest ledger sequence.
@@ -42,29 +67,55 @@ export async function getLedgerEntries(
 ): Promise<GetLedgerEntriesResult> {
   const { rpcUrl, keys, signal } = params
 
+  // Stable guard: an empty keys array never reaches the RPC endpoint and
+  // resolves to a handled empty result instead of an untyped request error.
+  if (keys.length === 0) {
+    return { entries: [], latestLedger: 0 }
+  }
+
   if (signal?.aborted) {
     throw new AbortError()
   }
 
   const requestId = toRpcRequestId()
-  const payload = buildJsonRpcRequest('getLedgerEntries', [keys], requestId)
 
-  try {
-    const response = await fetch(rpcUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(payload),
-      signal,
-    })
+  const result = await withRpcRetries<LedgerEntriesOpResult>(async () => {
+    const payload = buildJsonRpcRequest('getLedgerEntries', [keys], requestId)
+
+    let response: Response
+    try {
+      response = await fetch(rpcUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+        signal,
+      })
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.name === 'AbortError'
+      ) {
+        throw new AbortError()
+      }
+      // Surfaced as a retryable network error to the retry classifier.
+      return {
+        message: error instanceof Error ? error.message : 'Network error',
+        code: 'NETWORK_ERROR',
+      }
+    }
 
     if (signal?.aborted) {
       throw new AbortError()
     }
 
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`)
+      return {
+        message: `HTTP error! status: ${response.status}`,
+        code: response.status,
+        status: response.status,
+      }
     }
 
     const data = (await response.json()) as unknown
@@ -74,14 +125,17 @@ export async function getLedgerEntries(
     }
 
     if (isJsonRpcErrorResponse(data)) {
-      throw new Error(`RPC Error (${data.error.code}): ${data.error.message}`)
+      return {
+        message: `RPC Error (${data.error.code}): ${data.error.message}`,
+        code: data.error.code,
+      }
     }
 
     if (!isJsonRpcSuccessResponse(data)) {
-      throw new Error('Invalid JSON-RPC response format')
+      return { message: 'Invalid JSON-RPC response format', code: 'INVALID' }
     }
 
-    const result = data.result as {
+    const opResult = data.result as {
       entries: Array<{
         key: string
         xdr: string
@@ -92,22 +146,19 @@ export async function getLedgerEntries(
     }
 
     return {
-      entries: (result.entries || []).map((entry) => ({
+      entries: (opResult.entries ?? []).map((entry) => ({
         key: entry.key,
         xdr: entry.xdr,
         lastModifiedLedgerSeq: entry.lastModifiedLedgerSeq,
         liveUntilLedgerSeq: entry.liveUntilLedgerSeq,
       })),
-      latestLedger: result.latestLedger,
+      latestLedger: opResult.latestLedger,
     }
-  } catch (error) {
-    if (
-      signal?.aborted ||
-      (error instanceof Error && error.name === 'AbortError') ||
-      (error instanceof DOMException && error.name === 'AbortError')
-    ) {
-      throw new AbortError()
-    }
-    throw error
+  })
+
+  if (isRpcError(result)) {
+    throw new Error(result.message)
   }
+
+  return result
 }

--- a/src/test/network/getLedgerEntries.test.ts
+++ b/src/test/network/getLedgerEntries.test.ts
@@ -101,11 +101,22 @@ describe('getLedgerEntries', () => {
 
       const result = await getLedgerEntries({
         rpcUrl: mockRpcUrl,
-        keys: [],
+        keys: ['key1'],
       })
 
       expect(result.entries).toEqual([])
       expect(result.latestLedger).toBe(100)
+    })
+
+    it('returns a handled empty result for an empty keys array without a request', async () => {
+      const result = await getLedgerEntries({
+        rpcUrl: mockRpcUrl,
+        keys: [],
+      })
+
+      expect(result.entries).toEqual([])
+      expect(result.latestLedger).toBe(0)
+      expect(fetch).not.toHaveBeenCalled()
     })
   })
 
@@ -227,6 +238,59 @@ describe('getLedgerEntries', () => {
           signal: controller.signal,
         }),
       ).rejects.toThrow(AbortError)
+    })
+  })
+
+  describe('retry scenarios', () => {
+    it('retries a transient 429 then succeeds', async () => {
+      const success = {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          entries: [{ key: 'key1', xdr: 'xdr1' }],
+          latestLedger: 150,
+        },
+      }
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => success,
+        } as Response)
+
+      const result = await getLedgerEntries({
+        rpcUrl: mockRpcUrl,
+        keys: mockKeys,
+      })
+
+      expect(result.entries).toHaveLength(1)
+      expect(result.latestLedger).toBe(150)
+      expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('aborts promptly during retries instead of exhausting the cap', async () => {
+      const controller = new AbortController()
+      const abortError = new Error('The operation was aborted')
+      abortError.name = 'AbortError'
+
+      vi.mocked(fetch).mockImplementation(() => {
+        controller.abort()
+        return Promise.reject(abortError)
+      })
+
+      await expect(
+        getLedgerEntries({
+          rpcUrl: mockRpcUrl,
+          keys: mockKeys,
+          signal: controller.signal,
+        }),
+      ).rejects.toThrow(AbortError)
+
+      // AbortError is non-retryable, so the helper returns immediately.
+      expect(fetch).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
Routes the getLedgerEntries fetch path through the shared withRpcRetries policy so transient 429 and 5xx failures are retried up to the configured cap, while AbortSignal cancellation still aborts promptly. Also adds a stable empty-keys guard that returns a handled empty result instead of issuing an unclear RPC request. Closes #283
Closes #289