### PR TITLE
Persist watchlist across reloads

### DIFF
--- a/src/store/lensStore.ts
+++ b/src/store/lensStore.ts
@@ -405,7 +405,7 @@ const createWatchlistSlice = (
  * - ledgerData: Cached ledger entries (NOT persisted)
  * - expandedNodes: Tree view expansion state (NOT persisted)
  * - contractLoadStatus: Contract fetch lifecycle (NOT persisted)
- * - watchlist: Pinned keys for quick access (NOT persisted)
+ * - watchlist: Pinned keys for quick access (PERSISTED)
  */
 export const useLensStore = create<LensStore>()(
   persist<LensStore, [], [], PersistedState>(
@@ -423,13 +423,14 @@ export const useLensStore = create<LensStore>()(
     {
       name: NETWORK_CONFIG_STORAGE_KEY,
       storage: createSafeStorage<PersistedState>(),
-      // Persist networkConfig and preferences
+      // Persist networkConfig, preferences, and the watchlist
       partialize: (state): PersistedState => ({
         networkConfig: serializeNetworkConfigForStorage(state.networkConfig),
         preferences: {
           byteDisplayMode: state.byteDisplayMode,
           bigIntDisplayMode: state.bigIntDisplayMode,
         },
+        watchlist: state.watchlist,
       }),
       // Validate and merge persisted data safely
       merge: (persistedState, currentState) => ({

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -5,7 +5,7 @@ import { serializePersistedNetworkConfig } from '../lib/storage/serializePersist
 import { DEFAULT_NETWORKS } from './types'
 import { validateNetworkConfigPatch } from './validateNetworkConfigPatch'
 
-import type { NetworkConfig } from './types'
+import type { NetworkConfig, WatchlistItem } from './types'
 import type { PersistedNetworkConfig } from '../lib/storage/serializePersistedNetworkConfig'
 import type { PersistStorage } from 'zustand/middleware'
 
@@ -28,6 +28,7 @@ export interface PersistedState {
     byteDisplayMode: string
     bigIntDisplayMode: string
   }
+  watchlist?: Record<string, Array<WatchlistItem>>
 }
 
 /**
@@ -106,6 +107,17 @@ export function mergeNetworkConfig(
   persistedState: unknown,
   currentState: { networkConfig: NetworkConfig },
 ): any {
+  let watchlist: Record<string, Array<WatchlistItem>> = {}
+
+  if (
+    typeof persistedState === 'object' &&
+    persistedState !== null &&
+    'watchlist' in persistedState
+  ) {
+    const persisted = persistedState as { watchlist?: unknown }
+    watchlist = sanitizeWatchlist(persisted.watchlist)
+  }
+
   if (
     typeof persistedState === 'object' &&
     persistedState !== null &&
@@ -132,6 +144,7 @@ export function mergeNetworkConfig(
                 .bigIntDisplayMode,
             }
           : {}),
+        watchlist,
       }
     }
 
@@ -142,7 +155,55 @@ export function mergeNetworkConfig(
   }
 
   // Return current state (with defaults) if persisted data is invalid or missing
-  return currentState
+  return { ...currentState, watchlist }
+}
+
+/**
+ * Sanitizes a persisted watchlist into the known shape, dropping any entry
+ * that does not match the {@link WatchlistItem} contract. Guards against
+ * corrupted localStorage payloads crashing the store on hydration.
+ */
+export function sanitizeWatchlist(
+  value: unknown,
+): Record<string, Array<WatchlistItem>> {
+  if (typeof value !== 'object' || value === null) {
+    return {}
+  }
+
+  const source = value as Record<string, unknown>
+  const sanitized: Record<string, Array<WatchlistItem>> = {}
+
+  for (const [contractId, items] of Object.entries(source)) {
+    if (typeof contractId !== 'string' || contractId.length === 0) {
+      continue
+    }
+    if (!Array.isArray(items)) {
+      continue
+    }
+
+    const validItems: Array<WatchlistItem> = []
+    for (const item of items) {
+      if (
+        typeof item === 'object' &&
+        item !== null &&
+        'contractId' in item &&
+        'keyPath' in item &&
+        'timestamp' in item &&
+        typeof (item as Record<string, unknown>).contractId === 'string' &&
+        typeof (item as Record<string, unknown>).keyPath === 'string' &&
+        typeof (item as Record<string, unknown>).timestamp === 'number' &&
+        Number.isFinite((item as Record<string, unknown>).timestamp as number)
+      ) {
+        validItems.push(item as unknown as WatchlistItem)
+      }
+    }
+
+    if (validItems.length > 0) {
+      sanitized[contractId] = validItems
+    }
+  }
+
+  return sanitized
 }
 
 export function serializeNetworkConfigForStorage(

--- a/src/test/store/persistence.test.ts
+++ b/src/test/store/persistence.test.ts
@@ -5,6 +5,7 @@ import {
   clearPersistedNetworkConfig,
   isValidNetworkConfig,
   mergeNetworkConfig,
+  sanitizeWatchlist,
   serializeNetworkConfigForStorage,
 } from '../../store/persistence'
 import { DEFAULT_NETWORKS } from '../../store/types'
@@ -193,6 +194,90 @@ describe('persistence', () => {
       const persistedState = 'not an object'
       const result = mergeNetworkConfig(persistedState, currentState)
       expect(result.networkConfig).toEqual(DEFAULT_NETWORK_CONFIG)
+    })
+
+    it('hydrates a sanitized watchlist alongside a valid networkConfig', () => {
+      const watchlist = {
+        'C1': [
+          {
+            contractId: 'C1',
+            keyPath: 'counter',
+            timestamp: 1,
+          },
+        ],
+      }
+      const persistedState = {
+        networkConfig: {
+          kind: 'preset',
+          networkId: 'testnet',
+        },
+        watchlist,
+      }
+      const result = mergeNetworkConfig(persistedState, currentState)
+      expect(result.networkConfig).toEqual(DEFAULT_NETWORKS.testnet)
+      expect(result.watchlist).toEqual(watchlist)
+    })
+
+    it('drops invalid watchlist entries on hydration without crashing', () => {
+      const persistedState = {
+        networkConfig: {
+          kind: 'preset',
+          networkId: 'testnet',
+        },
+        watchlist: {
+          'C1': [
+            { contractId: 'C1', keyPath: 'ok', timestamp: 1 },
+            { contractId: 'C1', keyPath: 'bad' },
+            'not-an-item',
+            null,
+            { contractId: 2, keyPath: 'bad', timestamp: 1 },
+          ],
+          '': [{ contractId: 'C1', keyPath: 'x', timestamp: 1 }],
+          'C2': 'not-an-array',
+        },
+      }
+      const result = mergeNetworkConfig(persistedState, currentState)
+      expect(result.watchlist).toEqual({
+        C1: [{ contractId: 'C1', keyPath: 'ok', timestamp: 1 }],
+      })
+    })
+  })
+
+  describe('sanitizeWatchlist', () => {
+    it('returns an empty record for non-object input', () => {
+      expect(sanitizeWatchlist(null)).toEqual({})
+      expect(sanitizeWatchlist('x')).toEqual({})
+      expect(sanitizeWatchlist(undefined)).toEqual({})
+    })
+
+    it('drops contracts with empty keys or non-array items', () => {
+      const result = sanitizeWatchlist({
+        'C1': [{ contractId: 'C1', keyPath: 'k', timestamp: 1 }],
+        '': [{ contractId: 'C1', keyPath: 'k', timestamp: 1 }],
+        'C2': 'nope',
+      })
+      expect(result).toEqual({
+        C1: [{ contractId: 'C1', keyPath: 'k', timestamp: 1 }],
+      })
+    })
+
+    it('drops individual malformed items and keeps valid ones', () => {
+      const result = sanitizeWatchlist({
+        C1: [
+          { contractId: 'C1', keyPath: 'k', timestamp: 1 },
+          { contractId: 'C1', keyPath: 'k', timestamp: NaN },
+          { contractId: 'C1' },
+          { keyPath: 'k', timestamp: 1 },
+          { contractId: 'C1', keyPath: 1, timestamp: 1 },
+        ],
+      })
+      expect(result.C1).toHaveLength(1)
+      expect(result.C1[0].keyPath).toBe('k')
+    })
+
+    it('omits contracts whose items all failed validation', () => {
+      const result = sanitizeWatchlist({ C1: [{ bad: true }] })
+      expect(result).toEqual({})
     })
   })
 


### PR DESCRIPTION
Adds the watchlist slice to the persisted partial and sanitizes persisted watchlist items on hydration, dropping corrupted entries so a bad localStorage payload falls back safely without crashing. Closes #291