### PR TITLE
Add expand-all and collapse-all controls to explorer

### DIFF
--- a/src/lib/tree/flattenTree.ts
+++ b/src/lib/tree/flattenTree.ts
@@ -78,7 +78,7 @@ function walkNode(params: {
 
 export function flattenTree(
   roots: Array<FlattenTreeRoot>,
-  expandedNodeIds: ReadonlySet<string> | ReadonlyArray<string>,
+  expandedNodeIds: ReadonlyArray<string> | Set<string>,
 ): Array<FlatTreeRow> {
   const rows: Array<FlatTreeRow> = []
   const expandedIds =
@@ -99,4 +99,30 @@ export function flattenTree(
   }
 
   return rows
+}
+
+/**
+ * Returns every expandable node id in the supplied roots, regardless of the
+ * current expansion state. Used to drive expand-all controls for the explorer.
+ */
+export function collectExpandableNodeIds(
+  roots: Array<FlattenTreeRoot>,
+): Array<string> {
+  const ids: Array<string> = []
+
+  const visit = (node: Node, id: string): void => {
+    const children = getChildren(node)
+    if (isExpandable(node) && children.length > 0) {
+      ids.push(id)
+      for (const child of children) {
+        visit(child.node, `${id}.${child.idPart}`)
+      }
+    }
+  }
+
+  for (const root of roots) {
+    visit(root.node, root.id)
+  }
+
+  return ids
 }

--- a/src/routes/contracts/$contractId/explorer.tsx
+++ b/src/routes/contracts/$contractId/explorer.tsx
@@ -2,7 +2,10 @@ import { useEffect, useMemo } from 'react'
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { Button, Card, Heading } from '@stellar/design-system'
 import { VirtualizedTreeList } from '../../../components/explorer/VirtualizedTreeList'
-import { flattenTree } from '../../../lib/tree/flattenTree'
+import {
+  collectExpandableNodeIds,
+  flattenTree,
+} from '../../../lib/tree/flattenTree'
 import { ContractLoadStatus } from '../../../store/types'
 import { useLensStore } from '../../../store/lensStore'
 import { validateContractRouteParam } from './-validateContractRouteParam'
@@ -50,6 +53,8 @@ function ContractExplorer() {
   const contractLoadError = useLensStore((state) => state.contractLoadError)
   const expandedNodes = useLensStore((state) => state.expandedNodes)
   const toggleExpanded = useLensStore((state) => state.toggleExpanded)
+  const expandAll = useLensStore((state) => state.expandAll)
+  const collapseAll = useLensStore((state) => state.collapseAll)
   const selectedKeyPath = useLensStore((state) => state.selectedKeyPath)
   const setSelectedKeyPath = useLensStore((state) => state.setSelectedKeyPath)
 
@@ -105,6 +110,19 @@ function ContractExplorer() {
     () => flattenTree(treeRoots, expandedNodes),
     [expandedNodes, treeRoots],
   )
+
+  const expandableNodeIds = useMemo(
+    () => collectExpandableNodeIds(treeRoots),
+    [treeRoots],
+  )
+
+  const handleExpandAll = () => {
+    expandAll(expandableNodeIds)
+  }
+
+  const handleCollapseAll = () => {
+    collapseAll()
+  }
 
   useEffect(() => {
     setActiveContractId(contractId)
@@ -232,13 +250,34 @@ function ContractExplorer() {
       {contractLoadStatus === ContractLoadStatus.SUCCESS && (
         <Card>
           <div className="p-6 space-y-4">
-            <Heading
-              size="sm"
-              as="h3"
-              className="text-text-muted uppercase tracking-widest text-[11px] font-bold"
-            >
-              Explorer Rows ({flatRows.length})
-            </Heading>
+            <div className="flex items-center justify-between gap-4 flex-wrap">
+              <Heading
+                size="sm"
+                as="h3"
+                className="text-text-muted uppercase tracking-widest text-[11px] font-bold"
+              >
+                Explorer Rows ({flatRows.length})
+              </Heading>
+
+              {expandableNodeIds.length > 0 ? (
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleExpandAll}
+                  >
+                    Expand all
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleCollapseAll}
+                  >
+                    Collapse all
+                  </Button>
+                </div>
+              ) : null}
+            </div>
 
             {flatRows.length === 0 ? (
               <p className="text-text-muted text-sm">

--- a/src/test/tree/flattenTree.test.ts
+++ b/src/test/tree/flattenTree.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { flattenTree } from '../../lib/tree/flattenTree'
+import {
+  collectExpandableNodeIds,
+  flattenTree,
+} from '../../lib/tree/flattenTree'
 import type { Node } from '../../types/node'
 
 function primitive(value: string): Node {
@@ -76,5 +79,46 @@ describe('flattenTree', () => {
 
     const rows = flattenTree(roots, [])
     expect(rows.map((row) => row.kind)).toEqual(['unsupported', 'truncated'])
+  })
+})
+
+describe('collectExpandableNodeIds', () => {
+  const tree: Node = {
+    kind: 'map',
+    path: [],
+    raw: { switch: 'ScvMap' },
+    entries: [
+      {
+        key: primitive('k0'),
+        value: {
+          kind: 'vec',
+          path: [],
+          raw: { switch: 'ScvVec' },
+          items: [primitive('v0'), primitive('v1')],
+        },
+      },
+      {
+        key: primitive('k1'),
+        value: primitive('leaf'),
+      },
+    ],
+  }
+
+  it('returns the root and nested container ids regardless of expansion', () => {
+    const ids = collectExpandableNodeIds([
+      { id: 'root', label: 'root', node: tree },
+    ])
+    expect(ids).toEqual(['root', 'root.entry-0-value'])
+  })
+
+  it('returns an empty array for primitive roots', () => {
+    const ids = collectExpandableNodeIds([
+      { id: 'root', label: 'root', node: primitive('leaf') },
+    ])
+    expect(ids).toEqual([])
+  })
+
+  it('returns an empty array when there are no roots', () => {
+    expect(collectExpandableNodeIds([])).toEqual([])
   })
 })


### PR DESCRIPTION
Derives all expandable node ids from the current tree roots and wires Expand-all / Collapse-all controls in the explorer rows header to the existing store actions. Closes #299