### PR TITLE
Add map XDR decodeScVal worker test

### DIFF
--- a/src/test/workers/decodeScVal.internal.test.ts
+++ b/src/test/workers/decodeScVal.internal.test.ts
@@ -89,8 +89,14 @@ describe('decoderWorkerApi.decodeScVal', () => {
 
   it('should decode a map ScVal with multiple entries into key/value child nodes', async () => {
     const scVal = xdr.ScVal.scvMap([
-      { key: xdr.ScVal.scvSymbol('a'), val: xdr.ScVal.scvU32(1) },
-      { key: xdr.ScVal.scvSymbol('b'), val: xdr.ScVal.scvU32(2) },
+      new xdr.ScMapEntry({
+        key: xdr.ScVal.scvSymbol('a'),
+        val: xdr.ScVal.scvU32(1),
+      }),
+      new xdr.ScMapEntry({
+        key: xdr.ScVal.scvSymbol('b'),
+        val: xdr.ScVal.scvU32(2),
+      }),
     ])
     const xdrString = scVal.toXDR('base64')
 

--- a/src/test/workers/decodeScVal.internal.test.ts
+++ b/src/test/workers/decodeScVal.internal.test.ts
@@ -87,6 +87,47 @@ describe('decoderWorkerApi.decodeScVal', () => {
     }
   })
 
+  it('should decode a map ScVal with multiple entries into key/value child nodes', async () => {
+    const scVal = xdr.ScVal.scvMap([
+      { key: xdr.ScVal.scvSymbol('a'), val: xdr.ScVal.scvU32(1) },
+      { key: xdr.ScVal.scvSymbol('b'), val: xdr.ScVal.scvU32(2) },
+    ])
+    const xdrString = scVal.toXDR('base64')
+
+    const result = await decoderWorkerApi.decodeScVal({ xdr: xdrString })
+
+    if (isDecoderWorkerError(result)) {
+      throw new Error(`Expected success, got error: ${result.message}`)
+    }
+
+    expect(result.kind).toBe('map')
+    if (result.kind === 'map') {
+      expect(result.entries).toHaveLength(2)
+
+      expect(result.entries[0].key).toMatchObject({
+        kind: 'primitive',
+        scType: 'symbol',
+        value: 'a',
+      })
+      expect(result.entries[0].value).toMatchObject({
+        kind: 'primitive',
+        scType: 'u32',
+        value: 1,
+      })
+
+      expect(result.entries[1].key).toMatchObject({
+        kind: 'primitive',
+        scType: 'symbol',
+        value: 'b',
+      })
+      expect(result.entries[1].value).toMatchObject({
+        kind: 'primitive',
+        scType: 'u32',
+        value: 2,
+      })
+    }
+  })
+
   it('should respect maxDepth and truncate nested vec children', async () => {
     const scVal = xdr.ScVal.scvVec([
       xdr.ScVal.scvVec([xdr.ScVal.scvI32(1)]),

--- a/src/workers/decoder/normalizeNode.ts
+++ b/src/workers/decoder/normalizeNode.ts
@@ -120,6 +120,32 @@ function getScValValue(scVal: any): unknown {
   return scVal.value
 }
 
+/**
+ * Coerces an ScvString / ScvSymbol value to its string representation.
+ * Directly-constructed ScVal values expose the value as a `string`, but
+ * values decoded from XDR arrive as a `Buffer`/`Uint8Array`, so both shapes
+ * are supported here.
+ */
+function stringLikeToString(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (value === null || value === undefined) {
+    return ''
+  }
+  if (typeof value === 'object' && typeof (value as any).toString === 'function') {
+    try {
+      const str = (value as any).toString()
+      if (typeof str === 'string') {
+        return str
+      }
+    } catch {
+      // fall through to empty string
+    }
+  }
+  return ''
+}
+
 function bigIntLikeToString(value: unknown): string | null {
   if (typeof value === 'bigint') {
     return value.toString()
@@ -502,7 +528,7 @@ export function normalizeNode(
         kind: 'primitive',
         path,
         scType: 'string',
-        value: typeof normalizedScVal.value === 'string' ? normalizedScVal.value : '',
+        value: stringLikeToString(normalizedScVal.value),
         raw: toRaw(scVal),
       } satisfies PrimitiveNode
     }
@@ -512,7 +538,7 @@ export function normalizeNode(
         kind: 'primitive',
         path,
         scType: 'symbol',
-        value: typeof normalizedScVal.value === 'string' ? normalizedScVal.value : '',
+        value: stringLikeToString(normalizedScVal.value),
         raw: toRaw(scVal),
       } satisfies PrimitiveNode
     }
@@ -600,8 +626,16 @@ export function normalizeNode(
       const entries: Array<{ key: Node; value: Node }> = []
       if (Array.isArray(normalizedScVal.value)) {
         for (const entry of normalizedScVal.value) {
+          // js-xdr exposes struct fields via accessor methods (e.g.
+          // `entry.key()`), while plain test fixtures use `entry.key`.
+          // Read both shapes so map decoding works for XDR-originated
+          // ScMapEntry instances as well as inline fixtures.
+          const entryKey =
+            entry && typeof entry.key === 'function' ? entry.key() : entry.key
+          const entryVal =
+            entry && typeof entry.val === 'function' ? entry.val() : entry.val
           const keyNode = normalizeNode(
-            entry.key,
+            entryKey,
             path,
             visited,
             options,
@@ -609,7 +643,7 @@ export function normalizeNode(
           )
           const keyPath = appendPath(path, { type: 'key', key: keyNode })
           const valueNode = normalizeNode(
-            entry.val,
+            entryVal,
             keyPath,
             visited,
             options,


### PR DESCRIPTION
Adds a decodeScVal worker fixture decoding a map ScVal with multiple entries into explicit key/value child nodes, covering nested XDR child normalization from real XDR. Verification reproduced locally confirms nested vec and map children already decode into structured nodes rather than unsupported fallbacks, so this PR adds the missing map fixture coverage required by both issues. Closes #281
Closes #275