### PR TITLE
fix: remove duplicate keyboard toggle from network selector

### DIFF
--- a/src/components/global/NetworkSelector.tsx
+++ b/src/components/global/NetworkSelector.tsx
@@ -183,8 +183,6 @@ export default function NetworkSelector() {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       setIsOpen(false)
-    } else if (e.key === 'Enter' || e.key === ' ') {
-      setIsOpen(!isOpen)
     }
   }
 

--- a/src/test/components/NetworkSelector.test.tsx
+++ b/src/test/components/NetworkSelector.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import NetworkSelector from '../../components/global/NetworkSelector'
+
+// Mock the store
+vi.mock('../../store/lensStore', () => ({
+  useLensStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      networkConfig: { networkId: 'mainnet', rpcUrl: 'https://example.com', networkPassphrase: '' },
+      lastCustomUrl: '',
+      setNetworkConfig: vi.fn(),
+      setLastCustomUrl: vi.fn(),
+    }),
+}))
+
+describe('NetworkSelector', () => {
+  it('toggles dropdown on mouse click', () => {
+    render(<NetworkSelector />)
+
+    const button = screen.getByRole('button', { name: 'Select network' })
+    expect(button.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.click(button)
+    expect(button.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.click(button)
+    expect(button.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('toggles dropdown exactly once on Enter key', () => {
+    render(<NetworkSelector />)
+
+    const button = screen.getByRole('button', { name: 'Select network' })
+    expect(button.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.keyDown(button, { key: 'Enter' })
+    expect(button.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.keyDown(button, { key: 'Enter' })
+    expect(button.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('toggles dropdown exactly once on Space key', () => {
+    render(<NetworkSelector />)
+
+    const button = screen.getByRole('button', { name: 'Select network' })
+    expect(button.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.keyDown(button, { key: ' ' })
+    expect(button.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.keyDown(button, { key: ' ' })
+    expect(button.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('closes dropdown on Escape key', () => {
+    render(<NetworkSelector />)
+
+    const button = screen.getByRole('button', { name: 'Select network' })
+
+    fireEvent.click(button)
+    expect(button.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.keyDown(button, { key: 'Escape' })
+    expect(button.getAttribute('aria-expanded')).toBe('false')
+  })
+})

--- a/src/test/components/NetworkSelector.test.tsx
+++ b/src/test/components/NetworkSelector.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 import NetworkSelector from '../../components/global/NetworkSelector'
 
 // Mock the store

--- a/src/test/components/NetworkSelector.test.tsx
+++ b/src/test/components/NetworkSelector.test.tsx
@@ -34,9 +34,11 @@ describe('NetworkSelector', () => {
     expect(button.getAttribute('aria-expanded')).toBe('false')
 
     fireEvent.keyDown(button, { key: 'Enter' })
+    fireEvent.click(button)
     expect(button.getAttribute('aria-expanded')).toBe('true')
 
     fireEvent.keyDown(button, { key: 'Enter' })
+    fireEvent.click(button)
     expect(button.getAttribute('aria-expanded')).toBe('false')
   })
 
@@ -47,9 +49,11 @@ describe('NetworkSelector', () => {
     expect(button.getAttribute('aria-expanded')).toBe('false')
 
     fireEvent.keyDown(button, { key: ' ' })
+    fireEvent.click(button)
     expect(button.getAttribute('aria-expanded')).toBe('true')
 
     fireEvent.keyDown(button, { key: ' ' })
+    fireEvent.click(button)
     expect(button.getAttribute('aria-expanded')).toBe('false')
   })
 


### PR DESCRIPTION
Enter and Space keys were triggering both the native button click and the custom onKeyDown handler, toggling the dropdown twice.

Remove the redundant Enter/Space branch from handleKeyDown - the native button click handler already handles keyboard activation. Keep Escape handling while the menu is open.

Add tests to verify mouse click, Enter/Space, and Escape keyboard interactions.

Fixes #397