### PR TITLE
Render active contract label in sidebar header

### DIFF
--- a/src/components/global/Sidebar.tsx
+++ b/src/components/global/Sidebar.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, ChevronRight, ChevronUp, Filter, GitCompare, History as Hi
 import { useEffect, useMemo, useRef } from 'react'
 import { useLensStore } from '../../store/lensStore'
 import { resolveDiffStatus } from '../../lib/diff/resolveDiffStatus'
+import { formatContractIdShort } from '../../lib/format/formatContractIdShort'
 
 interface SidebarProps {
   open: boolean
@@ -20,6 +21,10 @@ export default function Sidebar({
 }: SidebarProps) {
   const isPinned = variant === 'pinned'
   const isHistory = activeNavItem === 'history'
+  const activeContractId = useLensStore((state) => state.activeContractId)
+  const activeContractLabel = activeContractId
+    ? formatContractIdShort(activeContractId)
+    : null
 
   // Pinned variant: inline panel
   if (isPinned) {
@@ -33,9 +38,19 @@ export default function Sidebar({
         <div className="w-100 flex flex-col h-full">
           {/* Panel Header */}
           <div className="h-10 border-b border-border-dark flex items-center justify-between px-4 bg-surface-dark/50 shrink-0">
-            <span className="text-xs font-bold text-text-muted uppercase tracking-wider font-mono">
-              {isHistory ? 'Compare History' : 'Ledger State'}
-            </span>
+            <div className="min-w-0 flex flex-col">
+              <span className="text-xs font-bold text-text-muted uppercase tracking-wider font-mono">
+                {isHistory ? 'Compare History' : 'Ledger State'}
+              </span>
+              {!isHistory && activeContractLabel ? (
+                <span
+                  className="text-[11px] font-mono text-white truncate max-w-[14rem]"
+                  title={activeContractId ?? undefined}
+                >
+                  {activeContractLabel}
+                </span>
+              ) : null}
+            </div>
             {!isHistory && (
               <div className="flex gap-2">
                 <button
@@ -162,9 +177,19 @@ export default function Sidebar({
       >
         {/* Panel Header */}
         <div className="h-10 border-b border-border-dark flex items-center justify-between px-4 bg-surface-dark/50 shrink-0">
-          <span className="text-xs font-bold text-text-muted uppercase tracking-wider font-mono">
-            {isHistory ? 'Compare History' : 'Ledger State'}
-          </span>
+          <div className="min-w-0 flex flex-col">
+            <span className="text-xs font-bold text-text-muted uppercase tracking-wider font-mono">
+              {isHistory ? 'Compare History' : 'Ledger State'}
+            </span>
+            {!isHistory && activeContractLabel ? (
+              <span
+                className="text-[11px] font-mono text-white truncate max-w-[14rem]"
+                title={activeContractId ?? undefined}
+              >
+                {activeContractLabel}
+              </span>
+            ) : null}
+          </div>
           <div className="flex gap-2">
             {!isHistory && (
               <button

--- a/src/test/components/SidebarHistory.test.tsx
+++ b/src/test/components/SidebarHistory.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import Sidebar from '../../components/global/Sidebar'
 import { resetStore, useLensStore } from '../../store/lensStore'
 import type { LedgerEntry } from '../../store/types'
+import { formatContractIdShort } from '../../lib/format/formatContractIdShort'
 
 const makeEntry = (key: string, contractId: string, value: unknown = 'value'): LedgerEntry => ({
   key,
@@ -23,6 +24,23 @@ describe('Sidebar History Panel', () => {
     expect(screen.getByText('Ledger State')).toBeTruthy()
     expect(screen.getByText('Contract_Registry')).toBeTruthy()
     expect(screen.queryByText('Capture First')).toBeNull()
+  })
+
+  it('shows a shortened active contract label in the sidebar header', () => {
+    const activeContractId = 'CDLZFC3SYQJ4S7HBE6A5PTLQO7N4M3YX2WT4EFQ4PTJX3S7PZN6MTEST'
+    useLensStore.getState().setActiveContractId(activeContractId)
+
+    render(<Sidebar open={true} onClose={vi.fn()} activeNavItem="watchlist" />)
+
+    const label = screen.getByText(formatContractIdShort(activeContractId))
+    expect(label).toBeTruthy()
+    expect(label.getAttribute('title')).toBe(activeContractId)
+  })
+
+  it('hides the active contract label when no contract is active', () => {
+    render(<Sidebar open={true} onClose={vi.fn()} activeNavItem="watchlist" />)
+
+    expect(screen.queryByText('-')).toBeNull()
   })
 
   it('renders no active contract message when activeNavItem is history but activeContractId is null', () => {


### PR DESCRIPTION
## Summary

- render the active contract label in the sidebar header when a contract is selected
- shorten the displayed contract ID with the existing formatter and keep the full value in the tooltip
- add sidebar coverage for both the visible and hidden contract-label states

## Why

The sidebar header previously showed only a static title, so users had no contract context while exploring ledger state. This change makes the active contract visible without changing the tree layout or adding new sections.

## Validation

```text
npm test -- --run src/test/components/TreeRow.test.tsx src/test/format/formatContractIdShort.test.ts src/test/components/SidebarHistory.test.tsx
  Test Files  3 passed (3)
  Tests       19 passed (19)

npm run build
  vite build && tsc
  PASS
```

Closes #311
