### PR TITLE
test: add resolveDiffStatus tests for object and array values

### DIFF
--- a/src/test/diff/resolveDiffStatus.test.ts
+++ b/src/test/diff/resolveDiffStatus.test.ts
@@ -144,6 +144,31 @@ describe('resolveDiffStatus', () => {
     })
   })
 
+  describe('objects and arrays', () => {
+    it('returns "unchanged" when both arguments are the same object reference', () => {
+      const obj = { a: 1, b: 'hello' }
+      expect(resolveDiffStatus(obj, obj)).toBe('unchanged')
+    })
+
+    it('returns "changed" for two distinct objects with the same shape', () => {
+      expect(resolveDiffStatus({ a: 1, b: 'hello' }, { a: 1, b: 'hello' })).toBe('changed')
+    })
+
+    it('returns "unchanged" when both arguments are the same array reference', () => {
+      const arr = [1, 2, 3]
+      expect(resolveDiffStatus(arr, arr)).toBe('unchanged')
+    })
+
+    it('returns "changed" for two distinct arrays with the same elements', () => {
+      expect(resolveDiffStatus([1, 2, 3], [1, 2, 3])).toBe('changed')
+    })
+
+    it('returns "changed" for arrays of different lengths', () => {
+      expect(resolveDiffStatus([1, 2], [1, 2, 3])).toBe('changed')
+      expect(resolveDiffStatus([1, 2, 3], [1])).toBe('changed')
+    })
+  })
+
   describe('invalid input', () => {
     it('handles function values', () => {
       const fn1 = () => {}


### PR DESCRIPTION
closes #304 
Add resolveDiffStatus tests for object and array values
  
  Adds a dedicated objects and arrays describe block to the resolveDiffStatus
   test suite, covering structured value behavior that was previously
  unspecified.
  
  What's new:
  
  - Equal object reference → unchanged
  - Distinct objects with the same shape → changed
  - Equal array reference → unchanged
  - Distinct arrays with the same elements → changed
  - Arrays of different lengths → changed
  
  These tests document the current shallow-reference behavior of
  resolveDiffStatus without modifying any production logic.