### PR TITLE
fix: Deduplicate watchlist items during hydration (fixes #381)

### DIFF
--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -230,7 +230,9 @@ export function sanitizeWatchlist(
       continue
     }
 
+    
     const validItems: Array<WatchlistItem> = []
+    const seenPaths = new Set<string>()
     for (const item of items) {
       if (
         typeof item === 'object' &&
@@ -243,9 +245,14 @@ export function sanitizeWatchlist(
         typeof (item as Record<string, unknown>).timestamp === 'number' &&
         Number.isFinite((item as Record<string, unknown>).timestamp as number)
       ) {
-        validItems.push(item as unknown as WatchlistItem)
+        const keyPath = (item as Record<string, unknown>).keyPath as string
+        if (!seenPaths.has(keyPath)) {
+          seenPaths.add(keyPath)
+          validItems.push(item as unknown as WatchlistItem)
+        }
       }
     }
+
 
     if (validItems.length > 0) {
       sanitized[contractId] = validItems

--- a/src/test/store/persistence.test.ts
+++ b/src/test/store/persistence.test.ts
@@ -244,6 +244,22 @@ describe('persistence', () => {
   })
 
   describe('sanitizeWatchlist', () => {
+
+    it('deduplicates watchlist items with identical keyPaths during hydration, preserving first-seen', () => {
+      const watchlist = {
+        'contract-1': [
+          { contractId: 'contract-1', keyPath: '/path1', timestamp: 100 },
+          { contractId: 'contract-1', keyPath: '/path1', timestamp: 200 },
+          { contractId: 'contract-1', keyPath: '/path2', timestamp: 300 }
+        ]
+      }
+      const hydratedState = { networkConfig: DEFAULT_NETWORKS.testnet, watchlist }
+      const result = mergeNetworkConfig(hydratedState, { networkConfig: DEFAULT_NETWORKS.futurenet })
+      expect(result.watchlist['contract-1']).toHaveLength(2)
+      expect(result.watchlist['contract-1'][0].timestamp).toBe(100) // Keeps first instance
+      expect(result.watchlist['contract-1'][1].keyPath).toBe('/path2')
+    })
+
     it('returns an empty record for non-object input', () => {
       expect(sanitizeWatchlist(null)).toEqual({})
       expect(sanitizeWatchlist('x')).toEqual({})


### PR DESCRIPTION
## Summary
Fixes #381.

## Changes
- Track seen `keyPath` values in `sanitizeWatchlist` using a `Set`.
- Preserve the first valid item for each key path, discarding duplicates.
- Add test cases checking deduplication and asserting that the first-seen timestamp is preserved.