### PR TITLE
[307] Add arrow-key navigation between tree rows

### DIFF
--- a/src/components/explorer/TreeRow.tsx
+++ b/src/components/explorer/TreeRow.tsx
@@ -1,12 +1,17 @@
 import type { FlatTreeRow } from '../../lib/tree/flatTreeRow'
+import type { KeyboardEvent, Ref } from 'react'
 
 interface TreeRowProps {
   row: FlatTreeRow
   isExpanded: boolean
   isSelected: boolean
   rowHeight: number
+  tabIndex?: number
+  rowRef?: Ref<HTMLDivElement>
   onToggleExpand?: (rowId: string) => void
   onActivate?: (row: FlatTreeRow) => void
+  onKeyNavigate?: (direction: 'up' | 'down') => void
+  onFocus?: () => void
 }
 
 function formatPreview(row: FlatTreeRow): string {
@@ -49,21 +54,41 @@ export function TreeRow({
   isExpanded,
   isSelected,
   rowHeight,
+  tabIndex = 0,
+  rowRef,
   onToggleExpand,
   onActivate,
+  onKeyNavigate,
+  onFocus,
 }: TreeRowProps) {
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      onKeyNavigate?.('down')
+      return
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      onKeyNavigate?.('up')
+      return
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      onActivate?.(row)
+    }
+  }
+
   return (
     <div
+      ref={rowRef}
       role="button"
-      tabIndex={0}
+      tabIndex={tabIndex}
       data-testid="tree-row"
       onClick={() => onActivate?.(row)}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault()
-          onActivate?.(row)
-        }
-      }}
+      onKeyDown={handleKeyDown}
+      onFocus={onFocus}
       className={`w-full flex items-center gap-2 px-3 border-b border-white/5 text-left ${
         isSelected ? 'bg-primary/10' : 'hover:bg-white/5'
       }`}

--- a/src/components/explorer/VirtualizedTreeList.tsx
+++ b/src/components/explorer/VirtualizedTreeList.tsx
@@ -97,8 +97,13 @@ export function VirtualizedTreeList({
 
     if (focusedRowIndex > rows.length - 1) {
       setFocusedRowIndex(rows.length - 1)
+      return
     }
-  }, [focusedRowIndex, rows.length])
+
+    if (focusedRowIndex < startIndex || focusedRowIndex >= endIndex) {
+      setFocusedRowIndex(startIndex)
+    }
+  }, [endIndex, focusedRowIndex, rows.length, startIndex])
 
   useEffect(() => {
     if (!pendingFocusRef.current) {

--- a/src/components/explorer/VirtualizedTreeList.tsx
+++ b/src/components/explorer/VirtualizedTreeList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { TreeRow } from './TreeRow'
 import type { UIEvent } from 'react'
 import type { FlatTreeRow } from '../../lib/tree/flatTreeRow'
@@ -25,6 +25,10 @@ export function VirtualizedTreeList({
   onActivateRow,
 }: VirtualizedTreeListProps) {
   const [scrollTop, setScrollTop] = useState(0)
+  const [focusedRowIndex, setFocusedRowIndex] = useState(0)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const focusedRowRef = useRef<HTMLDivElement>(null)
+  const pendingFocusRef = useRef(false)
 
   const expandedIds = useMemo(
     () =>
@@ -44,8 +48,70 @@ export function VirtualizedTreeList({
     setScrollTop(event.currentTarget.scrollTop)
   }
 
+  const scrollRowIntoView = (index: number) => {
+    const container = containerRef.current
+    if (!container || rows.length === 0) {
+      return
+    }
+
+    const rowTop = index * rowHeight
+    const rowBottom = rowTop + rowHeight
+    const viewTop = container.scrollTop
+    const viewBottom = viewTop + height
+
+    if (rowTop < viewTop) {
+      container.scrollTop = rowTop
+      setScrollTop(rowTop)
+    } else if (rowBottom > viewBottom) {
+      const nextScrollTop = rowBottom - height
+      container.scrollTop = nextScrollTop
+      setScrollTop(nextScrollTop)
+    }
+  }
+
+  const moveFocus = (direction: 'up' | 'down') => {
+    if (rows.length === 0) {
+      return
+    }
+
+    const delta = direction === 'down' ? 1 : -1
+    const nextIndex = Math.min(
+      rows.length - 1,
+      Math.max(0, focusedRowIndex + delta),
+    )
+
+    if (nextIndex === focusedRowIndex) {
+      return
+    }
+
+    pendingFocusRef.current = true
+    setFocusedRowIndex(nextIndex)
+    scrollRowIntoView(nextIndex)
+  }
+
+  useEffect(() => {
+    if (rows.length === 0) {
+      setFocusedRowIndex(0)
+      return
+    }
+
+    if (focusedRowIndex > rows.length - 1) {
+      setFocusedRowIndex(rows.length - 1)
+    }
+  }, [focusedRowIndex, rows.length])
+
+  useEffect(() => {
+    if (!pendingFocusRef.current) {
+      return
+    }
+
+    pendingFocusRef.current = false
+    focusedRowRef.current?.focus()
+  }, [focusedRowIndex, startIndex, endIndex])
+
   return (
     <div
+      ref={containerRef}
       className="overflow-auto rounded border border-border-dark bg-surface-dark/30"
       style={{ height }}
       onScroll={handleScroll}
@@ -56,6 +122,7 @@ export function VirtualizedTreeList({
           const rowIndex = startIndex + index
           const top = rowIndex * rowHeight
           const isExpanded = expandedIds.has(row.id)
+          const isFocused = rowIndex === focusedRowIndex
 
           return (
             <div
@@ -75,8 +142,12 @@ export function VirtualizedTreeList({
                 rowHeight={rowHeight}
                 isExpanded={isExpanded}
                 isSelected={selectedRowId === row.id}
+                tabIndex={isFocused ? 0 : -1}
+                rowRef={isFocused ? focusedRowRef : undefined}
                 onToggleExpand={onToggleExpand}
                 onActivate={onActivateRow}
+                onKeyNavigate={moveFocus}
+                onFocus={() => setFocusedRowIndex(rowIndex)}
               />
             </div>
           )

--- a/src/components/explorer/VirtualizedTreeList.tsx
+++ b/src/components/explorer/VirtualizedTreeList.tsx
@@ -105,8 +105,12 @@ export function VirtualizedTreeList({
       return
     }
 
+    if (!focusedRowRef.current) {
+      return
+    }
+
     pendingFocusRef.current = false
-    focusedRowRef.current?.focus()
+    focusedRowRef.current.focus()
   }, [focusedRowIndex, startIndex, endIndex])
 
   return (

--- a/src/test/components/TreeRow.test.tsx
+++ b/src/test/components/TreeRow.test.tsx
@@ -81,4 +81,48 @@ describe('TreeRow', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Open entry[0].value' }))
     expect(onActivate).toHaveBeenCalledWith(row)
   })
+
+  it('calls activate handler on Enter and Space', () => {
+    const onActivate = vi.fn()
+    const row = makeRow()
+
+    render(
+      <TreeRow
+        row={row}
+        rowHeight={40}
+        isExpanded={false}
+        isSelected={false}
+        onActivate={onActivate}
+      />,
+    )
+
+    const button = screen.getByRole('button', { name: 'Open entry[0].value' })
+    fireEvent.keyDown(button, { key: 'Enter' })
+    fireEvent.keyDown(button, { key: ' ' })
+
+    expect(onActivate).toHaveBeenCalledTimes(2)
+    expect(onActivate).toHaveBeenCalledWith(row)
+  })
+
+  it('notifies parent on ArrowUp and ArrowDown', () => {
+    const onKeyNavigate = vi.fn()
+    const row = makeRow()
+
+    render(
+      <TreeRow
+        row={row}
+        rowHeight={40}
+        isExpanded={false}
+        isSelected={false}
+        onKeyNavigate={onKeyNavigate}
+      />,
+    )
+
+    const button = screen.getByRole('button', { name: 'Open entry[0].value' })
+    fireEvent.keyDown(button, { key: 'ArrowDown' })
+    fireEvent.keyDown(button, { key: 'ArrowUp' })
+
+    expect(onKeyNavigate).toHaveBeenNthCalledWith(1, 'down')
+    expect(onKeyNavigate).toHaveBeenNthCalledWith(2, 'up')
+  })
 })

--- a/src/test/components/VirtualizedTreeList.test.tsx
+++ b/src/test/components/VirtualizedTreeList.test.tsx
@@ -44,6 +44,20 @@ describe('VirtualizedTreeList', () => {
     expect(screen.getByText('row-39')).toBeTruthy()
   })
 
+  it('keeps a tab stop in the mounted rows after scrolling', () => {
+    render(<VirtualizedTreeList rows={rows(120)} height={120} rowHeight={30} overscan={1} />)
+
+    const viewport = screen.getByTestId('virtualized-tree-list')
+    fireEvent.scroll(viewport, { target: { scrollTop: 1200 } })
+
+    const tabStops = screen
+      .getAllByRole('button')
+      .filter((button) => button.tabIndex === 0)
+
+    expect(tabStops).toHaveLength(1)
+    expect(tabStops[0]?.getAttribute('aria-label')).toBe('Open row-39')
+  })
+
   it('invokes row activation callback', () => {
     const onActivateRow = vi.fn()
 

--- a/src/test/components/VirtualizedTreeList.test.tsx
+++ b/src/test/components/VirtualizedTreeList.test.tsx
@@ -59,4 +59,55 @@ describe('VirtualizedTreeList', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Open row-0' }))
     expect(onActivateRow).toHaveBeenCalled()
   })
+
+  it('moves focus to the next row on ArrowDown', () => {
+    render(<VirtualizedTreeList rows={rows(5)} height={200} rowHeight={40} />)
+
+    const first = screen.getByRole('button', { name: 'Open row-0' })
+    first.focus()
+    fireEvent.keyDown(first, { key: 'ArrowDown' })
+
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', { name: 'Open row-1' }),
+    )
+  })
+
+  it('moves focus to the previous row on ArrowUp', () => {
+    render(<VirtualizedTreeList rows={rows(5)} height={200} rowHeight={40} />)
+
+    const first = screen.getByRole('button', { name: 'Open row-0' })
+    first.focus()
+    fireEvent.keyDown(first, { key: 'ArrowDown' })
+
+    const second = screen.getByRole('button', { name: 'Open row-1' })
+    fireEvent.keyDown(second, { key: 'ArrowUp' })
+
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', { name: 'Open row-0' }),
+    )
+  })
+
+  it('keeps Enter activation while navigating with arrows', () => {
+    const onActivateRow = vi.fn()
+
+    render(
+      <VirtualizedTreeList
+        rows={rows(5)}
+        height={200}
+        rowHeight={40}
+        onActivateRow={onActivateRow}
+      />,
+    )
+
+    const first = screen.getByRole('button', { name: 'Open row-0' })
+    first.focus()
+    fireEvent.keyDown(first, { key: 'ArrowDown' })
+
+    const second = screen.getByRole('button', { name: 'Open row-1' })
+    fireEvent.keyDown(second, { key: 'Enter' })
+
+    expect(onActivateRow).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'row-1' }),
+    )
+  })
 })


### PR DESCRIPTION
## Summary
- Track focused row index in `VirtualizedTreeList` and move DOM focus with ArrowUp/ArrowDown
- Preserve Enter/Space row activation and use roving tabindex for keyboard traversal
- Add unit coverage for arrow navigation and keyboard activation

## Test plan
- [x] `npm test` (1376 tests passed)
- [x] `npm run build` (vite + tsc)
- [ ] Focus a tree row and press ArrowDown/ArrowUp; confirm focus moves row by row
- [ ] Press Enter/Space on a focused row; confirm activation still works

Closes #307

Made with [Cursor](https://cursor.com)