### PR TITLE
Add formatScBytesByPreference helper

### DIFF
--- a/src/lib/format/formatScBytesByPreference.ts
+++ b/src/lib/format/formatScBytesByPreference.ts
@@ -1,0 +1,51 @@
+import { ByteDisplayMode } from '../../store/types'
+import { bytesToBase64 } from './bytesToBase64'
+import { formatScBytesHex } from './formatScBytesHex'
+
+/**
+ * Formats a byte array according to the given display preference.
+ *
+ * @param input - Byte-like value: Uint8Array, number array, or string.
+ * @param preference - The preferred display mode (hex, base64, etc).
+ * @returns The formatted string. Falls back to hex for unknown modes.
+ */
+export function formatScBytesByPreference(
+  input: Uint8Array | Array<number> | string,
+  preference: ByteDisplayMode
+): string {
+  if (preference === ByteDisplayMode.BASE64) {
+    let bytes: Uint8Array | undefined
+
+    if (typeof input === 'string') {
+      if (input.length === 0) {
+        return bytesToBase64(new Uint8Array())
+      }
+      try {
+        const decoded = atob(input)
+        bytes = new Uint8Array(decoded.split('').map(c => c.charCodeAt(0)))
+      } catch {
+        return formatScBytesHex(input)
+      }
+    } else if (Array.isArray(input)) {
+      for (const byte of input) {
+        if (
+          typeof byte !== 'number' ||
+          !Number.isInteger(byte) ||
+          byte < 0 ||
+          byte > 255
+        ) {
+          return formatScBytesHex(input)
+        }
+      }
+      bytes = new Uint8Array(input)
+    } else if (input instanceof Uint8Array) {
+      bytes = input
+    } else {
+      return formatScBytesHex(input)
+    }
+
+    return bytesToBase64(bytes)
+  }
+
+  return formatScBytesHex(input)
+}

--- a/src/test/format/formatScBytesByPreference.test.ts
+++ b/src/test/format/formatScBytesByPreference.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { formatScBytesByPreference } from '../../lib/format/formatScBytesByPreference'
+import { ByteDisplayMode } from '../../store/types'
+
+describe('formatScBytesByPreference', () => {
+  describe('HEX mode', () => {
+    it('returns hex string for Uint8Array', () => {
+      const bytes = new Uint8Array([1, 2, 3, 4, 5])
+      expect(formatScBytesByPreference(bytes, ByteDisplayMode.HEX)).toBe('0x0102030405')
+    })
+
+    it('returns hex string for number array', () => {
+      const bytes = [1, 2, 3, 4, 5]
+      expect(formatScBytesByPreference(bytes, ByteDisplayMode.HEX)).toBe('0x0102030405')
+    })
+
+    it('returns hex string for base64 string', () => {
+      expect(formatScBytesByPreference('AQIDBAU=', ByteDisplayMode.HEX)).toBe('0x0102030405')
+    })
+  })
+
+  describe('BASE64 mode', () => {
+    it('returns base64 string for Uint8Array', () => {
+      const bytes = new Uint8Array([1, 2, 3, 4, 5])
+      expect(formatScBytesByPreference(bytes, ByteDisplayMode.BASE64)).toBe('AQIDBAU=')
+    })
+
+    it('returns base64 string for number array', () => {
+      const bytes = [1, 2, 3, 4, 5]
+      expect(formatScBytesByPreference(bytes, ByteDisplayMode.BASE64)).toBe('AQIDBAU=')
+    })
+
+    it('returns base64 string for base64 string', () => {
+      expect(formatScBytesByPreference('AQIDBAU=', ByteDisplayMode.BASE64)).toBe('AQIDBAU=')
+    })
+  })
+
+  describe('unknown mode fallback', () => {
+    it('falls back to hex for UTF8 mode', () => {
+      const bytes = new Uint8Array([1, 2, 3, 4, 5])
+      expect(formatScBytesByPreference(bytes, ByteDisplayMode.UTF8)).toBe('0x0102030405')
+    })
+
+    it('falls back to hex for an arbitrary string as mode', () => {
+      const bytes = new Uint8Array([1, 2, 3, 4, 5])
+      expect(formatScBytesByPreference(bytes, 'unknown' as ByteDisplayMode)).toBe('0x0102030405')
+    })
+  })
+})


### PR DESCRIPTION
  I have successfully completed the task!

  Here is a summary of the work done:

  1. Created a new branch named add-formatScByte.
  2. Created the preference-aware wrapper formatScBytesByPreference inside src/lib/format/formatScBytesByPreference.
  ts.
      • It accepts a byte input (Uint8Array, array of numbers, or base64 string) and a ByteDisplayMode.
      • It correctly delegates to bytesToBase64 when the user's preference is ByteDisplayMode.BASE64.
      • It delegates to formatScBytesHex when the preference is ByteDisplayMode.HEX or for any unknown modes.
      • We kept the original two formatters (formatScBytesHex and bytesToBase64) completely untouched.
  3. Added comprehensive tests in src/test/format/formatScBytesByPreference.test.ts.
      • Included tests for rendering hex mode with various inputs.
      • Included tests for rendering base64 mode with various inputs.
      • Included tests for correctly falling back to hex mode for unknown modes (e.g., UTF8).
  4. Verified the changes by running npm run test and npm run build to ensure the type-checker, test runner, and
  bundler are completely satisfied. Everything passes successfully!

closes #303 