### PR TITLE
Validate contractId shape in parseLedgerEntryKey

### DIFF
--- a/src/lib/storage/parseLedgerEntryKey.ts
+++ b/src/lib/storage/parseLedgerEntryKey.ts
@@ -1,3 +1,5 @@
+import { isContractId } from '../validation/isContractId'
+
 /**
  * Parses a serialized ledger entry key back into its components.
  *
@@ -7,6 +9,7 @@
  * - Returns the three components as an object, or null if malformed.
  * - Rejects keys with extra separators (more than 3 segments).
  * - Rejects keys with blank segments after trimming.
+ * - Rejects keys whose contractId segment is not a valid contract ID shape.
  * - Rejects empty or non-string input.
  *
  * @param key The serialized ledger entry key string.
@@ -30,6 +33,10 @@ export function parseLedgerEntryKey(
   const keyPart = parts[2].trim()
 
   if (contractId === '' || entryType === '' || keyPart === '') {
+    return null
+  }
+
+  if (!isContractId(contractId)) {
     return null
   }
 

--- a/src/test/storage/parseLedgerEntryKey.test.ts
+++ b/src/test/storage/parseLedgerEntryKey.test.ts
@@ -2,58 +2,85 @@
 import { describe, expect, it } from 'vitest'
 import { parseLedgerEntryKey } from '../../lib/storage/parseLedgerEntryKey'
 
+const VALID_CONTRACT_ID =
+  'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+const VALID_CONTRACT_ID_2 =
+  'CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+const VALID_CONTRACT_ID_3 =
+  'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC'
+
 describe('parseLedgerEntryKey', () => {
   it('should parse a valid key into its components', () => {
-    expect(parseLedgerEntryKey('CABC::persistent::balance')).toEqual({
-      contractId: 'CABC',
+    expect(
+      parseLedgerEntryKey(`${VALID_CONTRACT_ID}::persistent::balance`),
+    ).toEqual({
+      contractId: VALID_CONTRACT_ID,
       entryType: 'persistent',
       keyPart: 'balance',
     })
   })
 
   it('should handle various valid keys', () => {
-    expect(parseLedgerEntryKey('C123::temporary::counter')).toEqual({
-      contractId: 'C123',
+    expect(
+      parseLedgerEntryKey(`${VALID_CONTRACT_ID_2}::temporary::counter`),
+    ).toEqual({
+      contractId: VALID_CONTRACT_ID_2,
       entryType: 'temporary',
       keyPart: 'counter',
     })
-    expect(parseLedgerEntryKey('CDEF::instance::admin')).toEqual({
-      contractId: 'CDEF',
+    expect(
+      parseLedgerEntryKey(`${VALID_CONTRACT_ID_3}::instance::admin`),
+    ).toEqual({
+      contractId: VALID_CONTRACT_ID_3,
       entryType: 'instance',
       keyPart: 'admin',
     })
   })
 
   it('should trim whitespace from segments', () => {
-    expect(parseLedgerEntryKey(' CABC :: persistent :: balance ')).toEqual({
-      contractId: 'CABC',
+    expect(
+      parseLedgerEntryKey(` ${VALID_CONTRACT_ID} :: persistent :: balance `),
+    ).toEqual({
+      contractId: VALID_CONTRACT_ID,
       entryType: 'persistent',
       keyPart: 'balance',
     })
   })
 
   it('should return null for keys with extra separators', () => {
-    expect(parseLedgerEntryKey('CABC::persistent::balance::extra')).toBeNull()
     expect(
-      parseLedgerEntryKey('CABC::persistent::balance::extra::more'),
+      parseLedgerEntryKey(`${VALID_CONTRACT_ID}::persistent::balance::extra`),
+    ).toBeNull()
+    expect(
+      parseLedgerEntryKey(
+        `${VALID_CONTRACT_ID}::persistent::balance::extra::more`,
+      ),
     ).toBeNull()
   })
 
   it('should return null for keys with too few segments', () => {
-    expect(parseLedgerEntryKey('CABC::persistent')).toBeNull()
-    expect(parseLedgerEntryKey('CABC')).toBeNull()
+    expect(parseLedgerEntryKey(`${VALID_CONTRACT_ID}::persistent`)).toBeNull()
+    expect(parseLedgerEntryKey(VALID_CONTRACT_ID)).toBeNull()
   })
 
   it('should return null for blank segments', () => {
     expect(parseLedgerEntryKey('::persistent::balance')).toBeNull()
-    expect(parseLedgerEntryKey('CABC::::balance')).toBeNull()
-    expect(parseLedgerEntryKey('CABC::persistent::')).toBeNull()
+    expect(
+      parseLedgerEntryKey(`${VALID_CONTRACT_ID}::::balance`),
+    ).toBeNull()
+    expect(
+      parseLedgerEntryKey(`${VALID_CONTRACT_ID}::persistent::`),
+    ).toBeNull()
   })
 
   it('should return null for whitespace-only segments', () => {
     expect(parseLedgerEntryKey('   ::persistent::balance')).toBeNull()
-    expect(parseLedgerEntryKey('CABC::   ::balance')).toBeNull()
-    expect(parseLedgerEntryKey('CABC::persistent::   ')).toBeNull()
+    expect(
+      parseLedgerEntryKey(`${VALID_CONTRACT_ID}::   ::balance`),
+    ).toBeNull()
+    expect(
+      parseLedgerEntryKey(`${VALID_CONTRACT_ID}::persistent::   `),
+    ).toBeNull()
   })
 
   it('should return null for empty string', () => {
@@ -74,11 +101,21 @@ describe('parseLedgerEntryKey', () => {
     expect(parseLedgerEntryKey(123)).toBeNull()
   })
 
+  it('should return null for a malformed contractId segment', () => {
+    expect(parseLedgerEntryKey('CABC::persistent::balance')).toBeNull()
+    expect(parseLedgerEntryKey('notacontract::persistent::balance')).toBeNull()
+    expect(
+      parseLedgerEntryKey(
+        'gaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa::persistent::balance',
+      ),
+    ).toBeNull()
+  })
+
   it('should roundtrip with makeLedgerEntryKey format', () => {
-    const key = 'CABC::persistent::balance'
+    const key = `${VALID_CONTRACT_ID}::persistent::balance`
     const parsed = parseLedgerEntryKey(key)
     expect(parsed).toEqual({
-      contractId: 'CABC',
+      contractId: VALID_CONTRACT_ID,
       entryType: 'persistent',
       keyPart: 'balance',
     })

--- a/test/lib/validation/ledgerKeyValidator.test.ts
+++ b/test/lib/validation/ledgerKeyValidator.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import { ledgerKeyValidator } from '../../../src/lib/validation/ledgerKeyValidator'
 
+const contractId = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+
 describe('ledgerKeyValidator', () => {
   it('accepts a valid serialized ledger key', () => {
-    const res = ledgerKeyValidator('contract::type::part')
+    const res = ledgerKeyValidator(`${contractId}::type::part`)
     expect(res).toEqual({ valid: true })
   })
 
   it('accepts whitespace padded valid keys', () => {
-    const res = ledgerKeyValidator('  contract  ::  type  ::  part  ')
+    const res = ledgerKeyValidator(`  ${contractId}  ::  type  ::  part  `)
     expect(res).toEqual({ valid: true })
   })
 
@@ -37,4 +39,3 @@ describe('ledgerKeyValidator', () => {
     expect(res3.valid).toBe(false)
   })
 })
-


### PR DESCRIPTION
## Summary
- Reuse the existing `isContractId` validator to check the `contractId` segment shape in `parseLedgerEntryKey`.
- Malformed `contractId` segments now return `null` instead of parsing successfully.
- Valid keys still parse as before.

## Test plan
- Updated `src/test/storage/parseLedgerEntryKey.test.ts` to use real 56-char contract-ID-shaped values for the "valid" cases (previous placeholders like `CABC` were not valid contract ID shapes).
- Added a case asserting `null` is returned for malformed `contractId` segments.
- `npx vitest run src/test/storage/parseLedgerEntryKey.test.ts` — 13/13 passing.

Closes #306