### PR TITLE
Add GitHub bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report a bug so maintainers can reproduce and fix it
+title: "[Bug] "
+labels: ["bug"]
+---
+
+## Summary
+
+<!-- One or two sentences describing the problem. -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What you expected to happen. -->
+
+## Actual Behavior
+
+<!-- What actually happened. Include error messages if any. -->
+
+## Environment
+
+- OS:
+- Browser (if applicable):
+- App / package version:
+- Network (Mainnet / Testnet / Futurenet / Local):
+
+## Additional Context
+
+<!-- Screenshots, logs, or related issues (optional). -->


### PR DESCRIPTION
## Summary
- Adds a markdown bug report issue template at `.github/ISSUE_TEMPLATE/bug_report.md`
- Includes short fields for summary, steps to reproduce, expected behavior, actual behavior, and environment
- Fixes #318

## Test plan
- [x] Confirm template is recognized via GitHub `issueTemplates` API on the fork
- [ ] Open https://github.com/Vynix-Labs/Soroban-state-lens/issues/new/choose after merge and confirm **Bug report** appears
- [ ] Select the template and confirm sections load (Summary, Steps, Expected, Actual, Environment)