### PR TITLE
feat: implement custom RPC network selection with persistent configuration support and validation testing.

### DIFF
--- a/src/components/global/NetworkSelector.tsx
+++ b/src/components/global/NetworkSelector.tsx
@@ -26,6 +26,7 @@ export default function NetworkSelector() {
   const [isOpen, setIsOpen] = useState(false)
   const [showCustomInput, setShowCustomInput] = useState(false)
   const [customRpcUrl, setCustomRpcUrl] = useState('')
+  const [customNetworkPassphrase, setCustomNetworkPassphrase] = useState('')
   const [validationError, setValidationError] = useState('')
   const [testStatus, setTestStatus] = useState<
     'idle' | 'loading' | 'success' | 'error'
@@ -44,16 +45,22 @@ export default function NetworkSelector() {
   useEffect(() => {
     setIsHydrated(true)
 
-    // If currently on custom network and we have a last custom URL, sync it
-    if (networkConfig.networkId === 'custom' && lastCustomUrl) {
-      setCustomRpcUrl(lastCustomUrl)
-      setShowCustomInput(true)
-    } else if (networkConfig.networkId === 'custom') {
-      // If custom but no last URL, use current config URL
-      setCustomRpcUrl(networkConfig.rpcUrl || '')
+    // If currently on custom network, sync RPC URL and passphrase
+    if (networkConfig.networkId === 'custom') {
+      if (lastCustomUrl) {
+        setCustomRpcUrl(lastCustomUrl)
+      } else {
+        setCustomRpcUrl(networkConfig.rpcUrl || '')
+      }
+      setCustomNetworkPassphrase(networkConfig.networkPassphrase || '')
       setShowCustomInput(true)
     }
-  }, [networkConfig.networkId, lastCustomUrl, networkConfig.rpcUrl])
+  }, [
+    networkConfig.networkId,
+    lastCustomUrl,
+    networkConfig.rpcUrl,
+    networkConfig.networkPassphrase,
+  ])
 
   // Auto-focus the input whenever the custom panel becomes visible
   useEffect(() => {
@@ -77,7 +84,7 @@ export default function NetworkSelector() {
     NETWORK_OPTIONS.find((opt) => opt.id === networkConfig.networkId) ||
     NETWORK_OPTIONS.find((opt) => opt.id === 'custom')!
 
-  // Initialize custom URL when switching to custom mode
+  // Initialize custom URL and passphrase when switching to custom mode
   const handleSelect = (option: NetworkInfo) => {
     if (option.config) {
       // Preset network: clear any custom URL usage and close everything
@@ -85,18 +92,24 @@ export default function NetworkSelector() {
       setShowCustomInput(false)
       setValidationError('')
       setCustomRpcUrl('')
+      setCustomNetworkPassphrase('')
       setIsOpen(false)
     } else {
       // Custom: restore last custom URL or set up for new input
-      const urlToUse = lastCustomUrl || networkConfig.rpcUrl || ''
+      const urlToUse = lastCustomUrl || (networkConfig.networkId === 'custom' ? networkConfig.rpcUrl : '') || ''
+      const passphraseToUse =
+        networkConfig.networkId === 'custom'
+          ? networkConfig.networkPassphrase || ''
+          : ''
       setNetworkConfig({
         networkId: 'custom',
-        networkPassphrase: '',
+        networkPassphrase: passphraseToUse || 'Custom Network',
         rpcUrl: urlToUse,
       })
-      setCustomRpcUrl(urlToUse) // ← preserve any previously typed/saved URL
-      setShowCustomInput(true) // ← show the input panel
-      setIsOpen(false) // ← close the dropdown list
+      setCustomRpcUrl(urlToUse)
+      setCustomNetworkPassphrase(passphraseToUse)
+      setShowCustomInput(true)
+      setIsOpen(false)
     }
   }
 
@@ -115,13 +128,11 @@ export default function NetworkSelector() {
       setNetworkConfig({
         networkId: 'custom',
         rpcUrl: customRpcUrl.trim(),
-        networkPassphrase: 'Custom Network',
+        networkPassphrase: customNetworkPassphrase.trim() || 'Custom Network',
       })
       setLastCustomUrl(customRpcUrl.trim())
       setShowCustomInput(false)
       setValidationError('')
-      // NOTE: We intentionally do NOT clear customRpcUrl here so that
-      // switching back to Custom restores the last typed value.
     } else {
       setValidationError(validation.error || 'Invalid URL')
     }
@@ -161,6 +172,7 @@ export default function NetworkSelector() {
     setValidationError('')
     // Restore the last successfully applied URL so re-opening Custom shows it
     setCustomRpcUrl(lastCustomUrl || '')
+    setCustomNetworkPassphrase(networkConfig.networkPassphrase || '')
   }
 
   const handleCustomUrlChange = (url: string) => {
@@ -174,9 +186,23 @@ export default function NetworkSelector() {
       setNetworkConfig({
         networkId: 'custom',
         rpcUrl: url.trim(),
+        networkPassphrase: customNetworkPassphrase.trim() || 'Custom Network',
       })
     } else {
       setValidationError(validation.error || 'Invalid URL')
+    }
+  }
+
+  const handleCustomPassphraseChange = (passphrase: string) => {
+    setCustomNetworkPassphrase(passphrase)
+
+    const validation = validateRpcUrl(customRpcUrl)
+    if (validation.isValid) {
+      setNetworkConfig({
+        networkId: 'custom',
+        rpcUrl: customRpcUrl.trim(),
+        networkPassphrase: passphrase.trim() || 'Custom Network',
+      })
     }
   }
 
@@ -237,7 +263,7 @@ export default function NetworkSelector() {
           <div className="space-y-3">
             <div className="flex items-center justify-between">
               <h3 className="text-sm font-medium text-text-main">
-                Custom RPC URL
+                Custom RPC Configuration
               </h3>
               <button
                 type="button"
@@ -251,30 +277,56 @@ export default function NetworkSelector() {
               </button>
             </div>
 
-            <div className="space-y-2">
-              <input
-                ref={inputRef}
-                type="text"
-                value={customRpcUrl}
-                onChange={(e) => handleCustomUrlChange(e.target.value)}
-                onBlur={handleCustomUrlBlur}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    handleApplyCustomUrl()
-                  } else if (e.key === 'Escape') {
-                    handleCancelCustom()
-                  }
-                }}
-                placeholder="https://rpc.example.com"
-                className={`w-full px-3 py-2 bg-background-dark border rounded-md text-sm text-white placeholder-text-muted transition-colors ${
-                  validationError
-                    ? 'border-red-500 focus:border-red-500'
-                    : 'border-border-dark focus:border-primary'
-                } focus:outline-none focus:ring-1 focus:ring-primary/20`}
-                aria-label="Custom RPC URL input"
-                aria-invalid={!!validationError}
-                aria-describedby={validationError ? 'rpc-error' : undefined}
-              />
+            <div className="space-y-3">
+              <div>
+                <label className="block text-xs text-text-muted mb-1 font-medium">
+                  RPC URL
+                </label>
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={customRpcUrl}
+                  onChange={(e) => handleCustomUrlChange(e.target.value)}
+                  onBlur={handleCustomUrlBlur}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      handleApplyCustomUrl()
+                    } else if (e.key === 'Escape') {
+                      handleCancelCustom()
+                    }
+                  }}
+                  placeholder="https://rpc.example.com"
+                  className={`w-full px-3 py-2 bg-background-dark border rounded-md text-sm text-white placeholder-text-muted transition-colors ${
+                    validationError
+                      ? 'border-red-500 focus:border-red-500'
+                      : 'border-border-dark focus:border-primary'
+                  } focus:outline-none focus:ring-1 focus:ring-primary/20`}
+                  aria-label="Custom RPC URL input"
+                  aria-invalid={!!validationError}
+                  aria-describedby={validationError ? 'rpc-error' : undefined}
+                />
+              </div>
+
+              <div>
+                <label className="block text-xs text-text-muted mb-1 font-medium">
+                  Network Passphrase
+                </label>
+                <input
+                  type="text"
+                  value={customNetworkPassphrase}
+                  onChange={(e) => handleCustomPassphraseChange(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      handleApplyCustomUrl()
+                    } else if (e.key === 'Escape') {
+                      handleCancelCustom()
+                    }
+                  }}
+                  placeholder="Test SDF Network ; September 2015"
+                  className="w-full px-3 py-2 bg-background-dark border border-border-dark focus:border-primary rounded-md text-sm text-white placeholder-text-muted transition-colors focus:outline-none focus:ring-1 focus:ring-primary/20"
+                  aria-label="Custom Network Passphrase input"
+                />
+              </div>
 
               {validationError && (
                 <p

--- a/src/lib/storage/parsePersistedNetworkConfig.ts
+++ b/src/lib/storage/parsePersistedNetworkConfig.ts
@@ -22,7 +22,10 @@ function parsePreset(networkId: unknown): NetworkConfig | null {
   return null
 }
 
-function parseCustom(rpcUrl: unknown): NetworkConfig | null {
+function parseCustom(
+  rpcUrl: unknown,
+  networkPassphrase?: unknown,
+): NetworkConfig | null {
   if (typeof rpcUrl !== 'string') {
     return null
   }
@@ -32,9 +35,14 @@ function parseCustom(rpcUrl: unknown): NetworkConfig | null {
     return null
   }
 
+  const passphrase =
+    typeof networkPassphrase === 'string' && networkPassphrase.trim().length > 0
+      ? networkPassphrase.trim()
+      : 'Custom Network'
+
   return {
     networkId: 'custom',
-    networkPassphrase: 'Custom Network',
+    networkPassphrase: passphrase,
     rpcUrl: normalizedRpcUrl,
     horizonUrl: FALLBACK.horizonUrl,
   }
@@ -48,7 +56,7 @@ function parseLegacyNetworkConfig(
     return preset
   }
 
-  return parseCustom(input.rpcUrl)
+  return parseCustom(input.rpcUrl, input.networkPassphrase)
 }
 
 export function parsePersistedNetworkConfig(input: unknown): NetworkConfig {
@@ -63,7 +71,11 @@ export function parsePersistedNetworkConfig(input: unknown): NetworkConfig {
   }
 
   if (persisted.kind === 'custom') {
-    return parseCustom(persisted.rpcUrl) ?? { ...FALLBACK }
+    return (
+      parseCustom(persisted.rpcUrl, persisted.networkPassphrase) ?? {
+        ...FALLBACK,
+      }
+    )
   }
 
   return parseLegacyNetworkConfig(input) ?? { ...FALLBACK }

--- a/src/lib/storage/serializePersistedNetworkConfig.ts
+++ b/src/lib/storage/serializePersistedNetworkConfig.ts
@@ -11,6 +11,7 @@ export type PersistedNetworkConfig =
   | {
       kind: 'custom'
       rpcUrl: string
+      networkPassphrase?: string
     }
 
 const PRESET_NETWORK_IDS = new Set(['futurenet', 'testnet', 'mainnet'])
@@ -35,10 +36,18 @@ export function serializePersistedNetworkConfig(
 
   const rpcUrl = normalizeRpcUrl(config.rpcUrl)
   if (rpcUrl !== '') {
-    return {
+    const customConfig: PersistedNetworkConfig = {
       kind: 'custom',
       rpcUrl,
     }
+    if (
+      typeof config.networkPassphrase === 'string' &&
+      config.networkPassphrase.trim().length > 0 &&
+      config.networkPassphrase !== 'Custom Network'
+    ) {
+      customConfig.networkPassphrase = config.networkPassphrase.trim()
+    }
+    return customConfig
   }
 
   return {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -72,6 +72,12 @@ const ContractsContractIdHistoryRoute =
     path: '/history',
     getParentRoute: () => ContractsContractIdRoute,
   } as any)
+const ContractsContractIdHistoryRoute =
+  ContractsContractIdHistoryRouteImport.update({
+    id: '/contracts/$contractId/history',
+    path: '/contracts/$contractId/history',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ContractsContractIdExplorerRoute =
   ContractsContractIdExplorerRouteImport.update({
     id: '/explorer',
@@ -259,6 +265,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/contracts/$contractId/history'
       preLoaderRoute: typeof ContractsContractIdHistoryRouteImport
       parentRoute: typeof ContractsContractIdRoute
+    }
+    '/contracts/$contractId/history': {
+      id: '/contracts/$contractId/history'
+      path: '/contracts/$contractId/history'
+      fullPath: '/contracts/$contractId/history'
+      preLoaderRoute: typeof ContractsContractIdHistoryRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/contracts/$contractId/explorer': {
       id: '/contracts/$contractId/explorer'

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -72,12 +72,6 @@ const ContractsContractIdHistoryRoute =
     path: '/history',
     getParentRoute: () => ContractsContractIdRoute,
   } as any)
-const ContractsContractIdHistoryRoute =
-  ContractsContractIdHistoryRouteImport.update({
-    id: '/contracts/$contractId/history',
-    path: '/contracts/$contractId/history',
-    getParentRoute: () => rootRouteImport,
-  } as any)
 const ContractsContractIdExplorerRoute =
   ContractsContractIdExplorerRouteImport.update({
     id: '/explorer',
@@ -265,13 +259,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/contracts/$contractId/history'
       preLoaderRoute: typeof ContractsContractIdHistoryRouteImport
       parentRoute: typeof ContractsContractIdRoute
-    }
-    '/contracts/$contractId/history': {
-      id: '/contracts/$contractId/history'
-      path: '/contracts/$contractId/history'
-      fullPath: '/contracts/$contractId/history'
-      preLoaderRoute: typeof ContractsContractIdHistoryRouteImport
-      parentRoute: typeof rootRouteImport
     }
     '/contracts/$contractId/explorer': {
       id: '/contracts/$contractId/explorer'

--- a/src/test/components/NetworkSelector.test.tsx
+++ b/src/test/components/NetworkSelector.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import NetworkSelector from '../../components/global/NetworkSelector'
+import { resetStore, useLensStore } from '../../store/lensStore'
+import { DEFAULT_NETWORKS } from '../../store/types'
+
+describe('NetworkSelector Component', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
+  it('renders with default preset network', () => {
+    render(<NetworkSelector />)
+    expect(screen.getByRole('button', { name: /select network/i })).toBeTruthy()
+    expect(screen.getByText('Futurenet')).toBeTruthy()
+  })
+
+  it('opens dropdown and switches to preset network', () => {
+    render(<NetworkSelector />)
+
+    const trigger = screen.getByRole('button', { name: /select network/i })
+    fireEvent.click(trigger)
+
+    const mainnetOption = screen.getByRole('option', { name: /mainnet/i })
+    fireEvent.click(mainnetOption)
+
+    const state = useLensStore.getState()
+    expect(state.networkConfig).toEqual(DEFAULT_NETWORKS.mainnet)
+  })
+
+  it('opens custom panel and captures custom url and network passphrase on apply', () => {
+    render(<NetworkSelector />)
+
+    const trigger = screen.getByRole('button', { name: /select network/i })
+    fireEvent.click(trigger)
+
+    const customOption = screen.getByRole('option', { name: /custom/i })
+    fireEvent.click(customOption)
+
+    expect(screen.getByText('Custom RPC Configuration')).toBeTruthy()
+
+    const urlInput = screen.getByLabelText('Custom RPC URL input')
+    const passphraseInput = screen.getByLabelText('Custom Network Passphrase input')
+
+    fireEvent.change(urlInput, { target: { value: 'https://custom-rpc.example.com' } })
+    fireEvent.change(passphraseInput, { target: { value: 'Test SDF Network ; September 2015' } })
+
+    const applyButton = screen.getByRole('button', { name: /apply/i })
+    fireEvent.click(applyButton)
+
+    const state = useLensStore.getState()
+    expect(state.networkConfig).toEqual({
+      networkId: 'custom',
+      rpcUrl: 'https://custom-rpc.example.com',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      horizonUrl: DEFAULT_NETWORKS.futurenet.horizonUrl,
+    })
+    expect(state.lastCustomUrl).toBe('https://custom-rpc.example.com')
+  })
+
+  it('defaults custom network passphrase to Custom Network when left empty', () => {
+    render(<NetworkSelector />)
+
+    const trigger = screen.getByRole('button', { name: /select network/i })
+    fireEvent.click(trigger)
+
+    const customOption = screen.getByRole('option', { name: /custom/i })
+    fireEvent.click(customOption)
+
+    const urlInput = screen.getByLabelText('Custom RPC URL input')
+    fireEvent.change(urlInput, { target: { value: 'https://custom-rpc2.example.com' } })
+
+    const applyButton = screen.getByRole('button', { name: /apply/i })
+    fireEvent.click(applyButton)
+
+    const state = useLensStore.getState()
+    expect(state.networkConfig.networkPassphrase).toBe('Custom Network')
+  })
+})

--- a/src/test/storage/parsePersistedNetworkConfig.test.ts
+++ b/src/test/storage/parsePersistedNetworkConfig.test.ts
@@ -27,6 +27,21 @@ describe('parsePersistedNetworkConfig', () => {
     })
   })
 
+  it('parses persisted custom rpc values with custom network passphrase', () => {
+    expect(
+      parsePersistedNetworkConfig({
+        kind: 'custom',
+        rpcUrl: 'https://rpc.custom.example.com/',
+        networkPassphrase: 'Test SDF Network ; September 2015',
+      }),
+    ).toEqual({
+      networkId: 'custom',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      rpcUrl: 'https://rpc.custom.example.com',
+      horizonUrl: DEFAULT_NETWORKS.futurenet.horizonUrl,
+    })
+  })
+
   it('supports the legacy persisted network config shape', () => {
     expect(
       parsePersistedNetworkConfig({

--- a/src/test/storage/serializePersistedNetworkConfig.test.ts
+++ b/src/test/storage/serializePersistedNetworkConfig.test.ts
@@ -36,6 +36,20 @@ describe('serializePersistedNetworkConfig', () => {
     })
   })
 
+  it('serializes custom rpc configs with custom network passphrases', () => {
+    expect(
+      serializePersistedNetworkConfig({
+        networkId: 'custom',
+        networkPassphrase: 'Test SDF Network ; September 2015',
+        rpcUrl: 'https://rpc.custom.example.com',
+      }),
+    ).toEqual({
+      kind: 'custom',
+      rpcUrl: 'https://rpc.custom.example.com',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+    })
+  })
+
   it('falls back safely when the rpc url cannot be normalized', () => {
     expect(
       serializePersistedNetworkConfig({


### PR DESCRIPTION
Closes #313 

- **Branch Created**: `add-network-passphrase-input-for-custom-rpc` off `main`.
- **UI Enhancements**:
  - Added a Network Passphrase text input field to the Custom RPC panel in [NetworkSelector.tsx](src/components/global/NetworkSelector.tsx).
  - Wired state handlers to capture and update the network passphrase when applying custom RPC settings or changing custom inputs in real-time.
  - Ensured switching between preset networks (Mainnet, Testnet, Futurenet) and Custom mode resets or restores custom passphrase values cleanly.
- **Storage Persistence**:
  - Updated [serializePersistedNetworkConfig.ts](src/lib/storage/serializePersistedNetworkConfig.ts) to serialize optional custom `networkPassphrase`.
  - Updated [parsePersistedNetworkConfig.ts](src/lib/storage/parsePersistedNetworkConfig.ts) to restore custom `networkPassphrase` from storage (defaulting to `"Custom Network"` if omitted).
- **Test Suite**:
  - Created [NetworkSelector.test.tsx](src/test/components/NetworkSelector.test.tsx) with component unit tests covering custom RPC URL and passphrase inputs, applying custom RPC settings, and preset selection behavior.
  - Added unit tests to `serializePersistedNetworkConfig.test.ts` and `parsePersistedNetworkConfig.test.ts`.
  - All 117 test files (1,378 tests) passed cleanly.