### PR TITLE
Normalize RPC timeout handling and validate latest ledger

### DIFF
--- a/src/lib/network/getLatestLedger.ts
+++ b/src/lib/network/getLatestLedger.ts
@@ -25,7 +25,12 @@ function parseLatestLedgerResult(value: unknown): LatestLedgerResult | null {
   }
 
   const candidate = value as Record<string, unknown>
-  if (typeof candidate.sequence !== 'number') {
+  if (
+    typeof candidate.sequence !== 'number' ||
+    !Number.isFinite(candidate.sequence) ||
+    !Number.isInteger(candidate.sequence) ||
+    candidate.sequence < 0
+  ) {
     return null
   }
 

--- a/src/lib/network/rpcClient.ts
+++ b/src/lib/network/rpcClient.ts
@@ -1,11 +1,13 @@
+import { normalizeTimeoutMs } from '../rpc/normalizeTimeoutMs'
 import type { RpcConfig, RpcError } from './types'
 
 export async function callRpc<T = unknown>(
   config: RpcConfig,
   body?: unknown,
 ): Promise<T | RpcError> {
+  const normalizedTimeout = normalizeTimeoutMs(config.timeout)
   const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), config.timeout)
+  const timeoutId = setTimeout(() => controller.abort(), normalizedTimeout)
 
   try {
     const response = await fetch(config.url, {
@@ -42,7 +44,7 @@ export async function callRpc<T = unknown>(
       return {
         message: 'Request timeout',
         code: 'TIMEOUT',
-        details: `Request timed out after ${config.timeout}ms`,
+        details: `Request timed out after ${normalizedTimeout}ms`,
         isTimeout: true,
       }
     }

--- a/src/store/contractSlice.ts
+++ b/src/store/contractSlice.ts
@@ -17,8 +17,9 @@ export const createContractSlice = (
   selectedKeyPath: null,
 
   setActiveContractId: (id: string) =>
-    set(() => ({
+    set((state) => ({
       activeContractId: id,
+      ...(id !== state.activeContractId ? { selectedKeyPath: null } : {}),
     })),
 
   clearActiveContractId: () =>

--- a/src/test/network/getLatestLedger.test.ts
+++ b/src/test/network/getLatestLedger.test.ts
@@ -67,6 +67,28 @@ describe('getLatestLedgerConnectionCheck', () => {
     })
   })
 
+  it.each([
+    { sequence: -1 },
+    { sequence: 1.5 },
+    { sequence: Number.NaN },
+    { sequence: Number.POSITIVE_INFINITY },
+  ])('rejects invalid ledger sequence $sequence', async ({ sequence }) => {
+    vi.spyOn(rpcClient, 'callRpc').mockResolvedValue({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        sequence,
+      },
+    } as any)
+
+    const result = await getLatestLedgerConnectionCheck('https://weird-rpc.com')
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Invalid response from RPC server',
+    })
+  })
+
   it('handles unexpected thrown errors', async () => {
     vi.spyOn(rpcClient, 'callRpc').mockRejectedValue(new Error('Fatal error'))
 

--- a/src/test/network/rpcClient.test.ts
+++ b/src/test/network/rpcClient.test.ts
@@ -105,7 +105,7 @@ describe('callRpc', () => {
         new DOMException('The operation was aborted.', 'AbortError'),
       )
 
-      const result = await callRpc({ ...defaultConfig, timeout: input as number })
+      const result = await callRpc({ ...defaultConfig, timeout: input })
 
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expected)
       expect(result).toMatchObject({

--- a/src/test/network/rpcClient.test.ts
+++ b/src/test/network/rpcClient.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { callRpc } from '../../lib/network/rpcClient'
 import type { RpcConfig } from '../../lib/network/types'
 
@@ -15,6 +15,10 @@ describe('callRpc', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('should handle successful responses', async () => {
@@ -85,6 +89,33 @@ describe('callRpc', () => {
       isTimeout: true,
     })
   })
+
+  it.each([
+    { input: 0, expected: 10000 },
+    { input: -123, expected: 10000 },
+    { input: 1.9, expected: 1 },
+    { input: Number.NaN, expected: 10000 },
+    { input: Number.POSITIVE_INFINITY, expected: 10000 },
+  ])(
+    'normalizes timeout $input to $expected before scheduling the abort timer',
+    async ({ input, expected }) => {
+      vi.useFakeTimers()
+      const setTimeoutSpy = vi.spyOn(global, 'setTimeout')
+      mockFetch.mockRejectedValueOnce(
+        new DOMException('The operation was aborted.', 'AbortError'),
+      )
+
+      const result = await callRpc({ ...defaultConfig, timeout: input as number })
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expected)
+      expect(result).toMatchObject({
+        message: 'Request timeout',
+        code: 'TIMEOUT',
+        details: `Request timed out after ${expected}ms`,
+        isTimeout: true,
+      })
+    },
+  )
 
   it('should work without body parameter', async () => {
     const mockData = { status: 'ok' }

--- a/src/test/store/contractSlice.test.ts
+++ b/src/test/store/contractSlice.test.ts
@@ -29,4 +29,24 @@ describe('Contract Slice', () => {
 
     expect(getStoreState().activeContractId).toBe(null)
   })
+
+  it('clears the selected key path when switching to a different contract', () => {
+    const state = getStoreState()
+
+    state.setSelectedKeyPath('contract.entry-0-value')
+    state.setActiveContractId('ABC123')
+    state.setActiveContractId('XYZ789')
+
+    expect(getStoreState().selectedKeyPath).toBeNull()
+  })
+
+  it('preserves the selected key path when the same contract is set again', () => {
+    const state = getStoreState()
+
+    state.setActiveContractId('ABC123')
+    state.setSelectedKeyPath('contract.entry-0-value')
+    state.setActiveContractId('ABC123')
+
+    expect(getStoreState().selectedKeyPath).toBe('contract.entry-0-value')
+  })
 })


### PR DESCRIPTION
## Summary
This PR addresses three related issues in the RPC and store flows:

- Normalizes RPC timeout values before scheduling the abort timer, so invalid values no longer trigger immediate or non-finite timeouts.
- Uses the normalized timeout in timeout error details so error messages reflect the actual duration used.
- Tightens latest-ledger validation to reject negative, fractional, NaN, and infinite sequence values.
- Clears the selected key path when the active contract changes to a different contract, while preserving the selection for the same contract.

## Changes
- Applied the existing timeout normalizer in the RPC client.
- Updated timeout error messaging to report the normalized timeout.
- Added validation for latest-ledger sequence values to ensure only non-negative finite integers are accepted.
- Added store logic to clear selected key path on contract changes.
- Added regression tests covering timeout normalization, invalid latest-ledger sequences, and contract-switch selection behavior.

## Testing
- Ran targeted Vitest suites for:
  - RPC client
  - Latest ledger validation
  - Contract slice/store behavior


closes #361
closes #362
closes #383