### PR TITLE
fix: use React SVG attribute names in the watermark

### DIFF
--- a/src/components/Home/WatermarkBg.tsx
+++ b/src/components/Home/WatermarkBg.tsx
@@ -13,13 +13,13 @@ const WatermarkBg = () => {
           d="M24 4L6 14V34L24 44L42 34V14L24 4Z"
           fill="none"
           stroke="currentColor"
-          stroke-width="0.5"
+          strokeWidth="0.5"
         ></path>
         <path
           d="M24 10L10 18V30L24 38L38 30V18L24 10Z"
           fill="none"
           stroke="currentColor"
-          stroke-width="0.5"
+          strokeWidth="0.5"
         ></path>
         <path
           className="text-primary"

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -72,6 +72,12 @@ const ContractsContractIdHistoryRoute =
     path: '/history',
     getParentRoute: () => ContractsContractIdRoute,
   } as any)
+const ContractsContractIdHistoryRoute =
+  ContractsContractIdHistoryRouteImport.update({
+    id: '/contracts/$contractId/history',
+    path: '/contracts/$contractId/history',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ContractsContractIdExplorerRoute =
   ContractsContractIdExplorerRouteImport.update({
     id: '/explorer',
@@ -259,6 +265,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/contracts/$contractId/history'
       preLoaderRoute: typeof ContractsContractIdHistoryRouteImport
       parentRoute: typeof ContractsContractIdRoute
+    }
+    '/contracts/$contractId/history': {
+      id: '/contracts/$contractId/history'
+      path: '/contracts/$contractId/history'
+      fullPath: '/contracts/$contractId/history'
+      preLoaderRoute: typeof ContractsContractIdHistoryRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/contracts/$contractId/explorer': {
       id: '/contracts/$contractId/explorer'

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -72,12 +72,6 @@ const ContractsContractIdHistoryRoute =
     path: '/history',
     getParentRoute: () => ContractsContractIdRoute,
   } as any)
-const ContractsContractIdHistoryRoute =
-  ContractsContractIdHistoryRouteImport.update({
-    id: '/contracts/$contractId/history',
-    path: '/contracts/$contractId/history',
-    getParentRoute: () => rootRouteImport,
-  } as any)
 const ContractsContractIdExplorerRoute =
   ContractsContractIdExplorerRouteImport.update({
     id: '/explorer',
@@ -265,13 +259,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/contracts/$contractId/history'
       preLoaderRoute: typeof ContractsContractIdHistoryRouteImport
       parentRoute: typeof ContractsContractIdRoute
-    }
-    '/contracts/$contractId/history': {
-      id: '/contracts/$contractId/history'
-      path: '/contracts/$contractId/history'
-      fullPath: '/contracts/$contractId/history'
-      preLoaderRoute: typeof ContractsContractIdHistoryRouteImport
-      parentRoute: typeof rootRouteImport
     }
     '/contracts/$contractId/explorer': {
       id: '/contracts/$contractId/explorer'

--- a/src/test/components/WatermarkBg.test.tsx
+++ b/src/test/components/WatermarkBg.test.tsx
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import WatermarkBg from '../../components/Home/WatermarkBg'
+
+describe('WatermarkBg', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders without React unknown-property warnings', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { container } = render(<WatermarkBg />)
+
+    const unknownPropWarnings = errorSpy.mock.calls.filter((call) =>
+      call.some(
+        (arg) =>
+          typeof arg === 'string' &&
+          (arg.includes('unrecognized in this browser') ||
+            arg.includes('Invalid DOM property')),
+      ),
+    )
+    expect(unknownPropWarnings).toHaveLength(0)
+
+    const strokedPaths = container.querySelectorAll('path[stroke-width]')
+    expect(strokedPaths).toHaveLength(2)
+    strokedPaths.forEach((path) => {
+      expect(path.getAttribute('stroke-width')).toBe('0.5')
+      expect(path.getAttribute('stroke')).toBe('currentColor')
+    })
+  })
+})


### PR DESCRIPTION
Closes #430.

- Replaces the two kebab-case `stroke-width` props in `src/components/Home/WatermarkBg.tsx` with the React-compatible `strokeWidth`, so React stops warning about an unknown DOM property. Values (`0.5`), colors, and dimensions are unchanged — the rendered DOM attribute is still `stroke-width="0.5"`.
- Adds `src/test/components/WatermarkBg.test.tsx`: renders the component, asserts no unknown-prop/invalid-DOM-property console warning is emitted, and pins that both stroked paths keep `stroke-width="0.5"` and `stroke="currentColor"` in the output.

Verified locally: `npx vitest run src/test/components/WatermarkBg.test.tsx` passes; `eslint` clean on both files.