### PR TITLE
Reset custom RPC test status when URL changes

### DIFF
--- a/src/components/global/NetworkSelector.tsx
+++ b/src/components/global/NetworkSelector.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
 import { testRpcConnection } from '../../lib/network/testConnection'
+import { resetConnectionTestState } from '../../lib/network/connectionTestState'
 import { validateRpcUrl } from '../../lib/network/validation'
 import { useLensStore } from '../../store/lensStore'
 import { DEFAULT_NETWORKS } from '../../store/types'
@@ -165,6 +166,9 @@ export default function NetworkSelector() {
 
   const handleCustomUrlChange = (url: string) => {
     setCustomRpcUrl(url)
+    const resetState = resetConnectionTestState()
+    setTestStatus(resetState.status)
+    setTestError(resetState.error)
 
     const validation = validateRpcUrl(url)
     if (validation.isValid) {

--- a/src/lib/network/connectionTestState.ts
+++ b/src/lib/network/connectionTestState.ts
@@ -1,0 +1,6 @@
+export function resetConnectionTestState(): {
+  status: 'idle'
+  error: ''
+} {
+  return { status: 'idle', error: '' }
+}

--- a/src/test/network/connectionTestState.test.ts
+++ b/src/test/network/connectionTestState.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { resetConnectionTestState } from '../../lib/network/connectionTestState'
+
+describe('resetConnectionTestState', () => {
+  it('returns idle status with no previous error', () => {
+    expect(resetConnectionTestState()).toEqual({ status: 'idle', error: '' })
+  })
+})


### PR DESCRIPTION
Reset the custom RPC test result when the URL changes.

Closes #395