### PR TITLE
Associate contract lookup errors with the input

### DIFF
--- a/src/components/global/ContractLookUpInput.tsx
+++ b/src/components/global/ContractLookUpInput.tsx
@@ -81,6 +81,10 @@ function ContractLookUpInput() {
           }`}
           placeholder="Search ledger keys / contract IDs..."
           type="text"
+          aria-invalid={validationError !== null}
+          aria-describedby={
+            validationError ? 'contract-lookup-error' : undefined
+          }
           onBlur={async () => {
             const value = inputValue.trim()
             if (!value) return
@@ -111,7 +115,12 @@ function ContractLookUpInput() {
         </div>
       </div>
       {validationError && (
-        <p className="mt-2 text-sm text-red-500">{validationError}</p>
+        <p
+          id="contract-lookup-error"
+          className="mt-2 text-sm text-red-500"
+        >
+          {validationError}
+        </p>
       )}
     </form>
   )

--- a/src/test/components/ContractLookUpInput.test.tsx
+++ b/src/test/components/ContractLookUpInput.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import ContractLookUpInput from '../../components/global/ContractLookUpInput'
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock('../../lib/validation/contractId', () => ({
+  validateContractId: vi.fn().mockResolvedValue({
+    ok: false,
+    error: 'Invalid contract ID',
+  }),
+}))
+
+describe('ContractLookUpInput validation accessibility', () => {
+  it('links an active error to the input and clears the link after editing', async () => {
+    render(<ContractLookUpInput />)
+
+    const input = screen.getByPlaceholderText('Search ledger keys / contract IDs...')
+    fireEvent.change(input, { target: { value: 'invalid' } })
+    fireEvent.submit(input.closest('form')!)
+
+    await waitFor(() => {
+      expect(input.getAttribute('aria-invalid')).toBe('true')
+      expect(input.getAttribute('aria-describedby')).toBe('contract-lookup-error')
+      expect(screen.getByText('Invalid contract ID').id).toBe(
+        'contract-lookup-error',
+      )
+    })
+
+    fireEvent.change(input, { target: { value: 'still-invalid' } })
+
+    expect(input.getAttribute('aria-invalid')).toBe('false')
+    expect(input.getAttribute('aria-describedby')).toBeNull()
+  })
+})


### PR DESCRIPTION
Link contract lookup validation messages to the input with accessible error attributes.

Closes #394