### PR TITLE
Use deterministic key ordering in snapshot diffs

### DIFF
--- a/src/lib/diff/diffSnapshotEntries.ts
+++ b/src/lib/diff/diffSnapshotEntries.ts
@@ -46,6 +46,7 @@ export function diffSnapshotEntries(
     }
   }
 
-  diffResults.sort((a, b) => a.key.localeCompare(b.key))
+  // Use code-unit ordering so output does not depend on the runtime locale.
+  diffResults.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
   return diffResults
 }

--- a/src/test/diff/diffSnapshotEntries.test.ts
+++ b/src/test/diff/diffSnapshotEntries.test.ts
@@ -112,4 +112,18 @@ describe('diffSnapshotEntries', () => {
 
     expect(diff.map((item) => item.key)).toEqual(['key-1', 'key-2'])
   })
+
+  it('uses deterministic code-unit ordering for mixed-case and punctuation keys', () => {
+    const diff = diffSnapshotEntries(
+      { 'a-key': 1, 'A-key': 1, 'a.key': 1 },
+      { 'a-key': 1, 'A-key': 2, 'a.key': 3 },
+    )
+
+    expect(diff.map((item) => item.key)).toEqual(['A-key', 'a-key', 'a.key'])
+    expect(diff.map((item) => item.status)).toEqual([
+      'modified',
+      'unchanged',
+      'modified',
+    ])
+  })
 })


### PR DESCRIPTION
Use locale-independent key ordering for snapshot diff results and cover mixed keys.

Closes #390