### PR TITLE
Thread AbortSignal through latest-ledger checks

### DIFF
--- a/src/lib/network/getLatestLedger.ts
+++ b/src/lib/network/getLatestLedger.ts
@@ -47,12 +47,21 @@ function parseLatestLedgerResult(value: unknown): LatestLedgerResult | null {
 export async function getLatestLedgerConnectionCheck(
   url: string,
   timeoutMs?: number,
+  signal?: AbortSignal,
 ): Promise<GetLatestLedgerConnectionResult> {
+  if (signal?.aborted) {
+    return {
+      success: false,
+      error: 'Connection check aborted',
+    }
+  }
+
   try {
     const response = await callRpc(
       {
         url,
         timeout: timeoutMs ?? 5000,
+        signal,
       },
       buildJsonRpcRequest('getLatestLedger', {}, toRpcRequestId()),
     )
@@ -86,7 +95,11 @@ export async function getLatestLedgerConnectionCheck(
   } catch (error) {
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'Connection failed',
+      error: signal?.aborted
+        ? 'Connection check aborted'
+        : error instanceof Error
+          ? error.message
+          : 'Connection failed',
     }
   }
 }

--- a/src/test/network/getLatestLedger.test.ts
+++ b/src/test/network/getLatestLedger.test.ts
@@ -111,4 +111,58 @@ describe('getLatestLedgerConnectionCheck', () => {
       error: 'Fatal error',
     })
   })
+
+  it('passes a caller signal to the RPC request', async () => {
+    const signal = new AbortController().signal
+    const spy = vi.spyOn(rpcClient, 'callRpc').mockResolvedValue({
+      jsonrpc: '2.0',
+      id: 7,
+      result: { sequence: 1 },
+    })
+
+    await getLatestLedgerConnectionCheck('https://valid-rpc.com', 1234, signal)
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ signal }),
+      expect.anything(),
+    )
+  })
+
+  it('does not issue an RPC request when already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const spy = vi.spyOn(rpcClient, 'callRpc')
+    spy.mockClear()
+
+    const result = await getLatestLedgerConnectionCheck(
+      'https://valid-rpc.com',
+      undefined,
+      controller.signal,
+    )
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Connection check aborted',
+    })
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('handles cancellation during an in-flight request', async () => {
+    const controller = new AbortController()
+    vi.spyOn(rpcClient, 'callRpc').mockImplementation(() => {
+      controller.abort()
+      return Promise.reject(new DOMException('The operation was aborted', 'AbortError'))
+    })
+
+    await expect(
+      getLatestLedgerConnectionCheck(
+        'https://valid-rpc.com',
+        undefined,
+        controller.signal,
+      ),
+    ).resolves.toEqual({
+      success: false,
+      error: 'Connection check aborted',
+    })
+  })
 })


### PR DESCRIPTION
Thread caller abort signals through latest-ledger connection checks.

Closes #419