### PR TITLE
Recheck stale contract loads after decoding

### DIFF
--- a/src/store/lensStore.ts
+++ b/src/store/lensStore.ts
@@ -275,6 +275,7 @@ const createContractLoadSlice = (
       const controller = new AbortController()
       activeController = controller
       const { signal } = controller
+      const isRequestStale = () => currentRequestId !== requestId || signal.aborted
 
       set((state) => ({
         activeContractId: contractId,
@@ -291,7 +292,7 @@ const createContractLoadSlice = (
           signal,
         })
 
-        if (currentRequestId !== requestId || signal.aborted) {
+        if (isRequestStale()) {
           return
         }
 
@@ -303,6 +304,10 @@ const createContractLoadSlice = (
           decodedValuesByKey[entry.key] = isDecoderWorkerError(result)
             ? entry.xdr
             : result
+        }
+
+        if (isRequestStale()) {
+          return
         }
 
         const mappedEntries = mapLedgerEntriesToStoreEntries({
@@ -322,7 +327,7 @@ const createContractLoadSlice = (
           contractLoadError: null,
         }))
       } catch (error) {
-        if (currentRequestId !== requestId || signal.aborted) {
+        if (isRequestStale()) {
           return
         }
 

--- a/src/test/store/loadContractAction.test.ts
+++ b/src/test/store/loadContractAction.test.ts
@@ -159,4 +159,60 @@ describe('loadContract action', () => {
     expect(state.ledgerData['C_STALE::Other::new-key'].rawXdr).toBe('new-xdr')
     expect(state.ledgerData['C_STALE::Other::old-key']).toBeUndefined()
   })
+
+  it('ignores stale results that finish decoding after a newer request', async () => {
+    const { resetStore, getStoreState, useLensStore } = await import(
+      '../../store/lensStore',
+    )
+    resetStore()
+
+    let resolveFirstDecode: ((value: unknown) => void) | undefined
+    const firstDecode = new Promise<unknown>((resolve) => {
+      resolveFirstDecode = resolve
+    })
+    const firstWorker = { decodeScVal: vi.fn().mockReturnValue(firstDecode) }
+    const secondWorker = {
+      decodeScVal: vi.fn().mockResolvedValue({
+        kind: 'primitive',
+        path: [],
+        scType: 'string',
+        value: 'new',
+        raw: { switch: 'ScvString', value: 'new' },
+      }),
+    }
+
+    mockCreateDecoderWorkerSafe
+      .mockImplementationOnce(() => Promise.resolve(firstWorker))
+      .mockImplementationOnce(() => Promise.resolve(secondWorker))
+    mockGetLedgerEntries
+      .mockResolvedValueOnce({
+        entries: [{ key: 'old-key', xdr: 'old-xdr', lastModifiedLedgerSeq: 1 }],
+        latestLedger: 1,
+      })
+      .mockResolvedValueOnce({
+        entries: [{ key: 'new-key', xdr: 'new-xdr', lastModifiedLedgerSeq: 2 }],
+        latestLedger: 2,
+      })
+
+    const firstCall = useLensStore.getState().loadContract('C_DECODE_STALE', ['old'])
+    for (let attempt = 0; attempt < 10 && !firstWorker.decodeScVal.mock.calls.length; attempt += 1) {
+      await Promise.resolve()
+    }
+
+    const secondCall = useLensStore.getState().loadContract('C_DECODE_STALE', ['new'])
+    await secondCall
+    resolveFirstDecode?.({
+      kind: 'primitive',
+      path: [],
+      scType: 'string',
+      value: 'old',
+      raw: { switch: 'ScvString', value: 'old' },
+    })
+    await firstCall
+
+    const state = getStoreState()
+    expect(state.contractLoadStatus).toBe(ContractLoadStatus.SUCCESS)
+    expect(state.ledgerData['C_DECODE_STALE::Other::new-key'].rawXdr).toBe('new-xdr')
+    expect(state.ledgerData['C_DECODE_STALE::Other::old-key']).toBeUndefined()
+  })
 })


### PR DESCRIPTION
Guard decoded contract results before committing them to the store.

Closes #376