### PR TITLE
Add accessible name to header sidebar toggle

### DIFF
--- a/src/components/global/Header.tsx
+++ b/src/components/global/Header.tsx
@@ -12,10 +12,14 @@ export default function Header({ handleToggle }: HeaderProp) {
         {/* Left: Logo + Title */}
         <div className="flex items-center gap-3">
           <button
+            type="button"
             onClick={handleToggle}
+            aria-label="Toggle ledger state sidebar"
             className="size-8 bg-primary/20 rounded flex items-center justify-center text-primary"
           >
-            <span className="material-symbols-outlined">view_in_ar</span>
+            <span aria-hidden="true" className="material-symbols-outlined">
+              view_in_ar
+            </span>
           </button>
           <h1 className="font-mono font-bold text-white hidden xl:text-lg tracking-tight xl:flex">
             SOROBAN STATE LENS

--- a/src/test/components/Header.test.tsx
+++ b/src/test/components/Header.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import Header from '../../components/global/Header'
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+describe('Header sidebar toggle', () => {
+  it('has an accessible name and explicit button type', () => {
+    render(<Header handleToggle={vi.fn()} />)
+
+    const toggle = screen.getByRole('button', {
+      name: 'Toggle ledger state sidebar',
+    })
+    expect(toggle.getAttribute('type')).toBe('button')
+    expect(toggle.querySelector('[aria-hidden="true"]')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Add an accessible name and explicit button type to the header sidebar toggle.

Closes #393