### PR TITLE
Deduplicate expanded nodes in persisted state sanitizer

### DIFF
--- a/src/lib/storage/sanitizePersistedLensState.ts
+++ b/src/lib/storage/sanitizePersistedLensState.ts
@@ -28,9 +28,13 @@ export function sanitizePersistedLensState(input: unknown): {
   // Sanitize expandedNodes
   let expandedNodes: Array<string> = []
   if (Array.isArray(raw.expandedNodes)) {
-    expandedNodes = raw.expandedNodes.filter(
-      (nodeId): nodeId is string =>
-        typeof nodeId === 'string' && nodeId.trim().length > 0,
+    expandedNodes = Array.from(
+      new Set(
+        raw.expandedNodes.filter(
+          (nodeId): nodeId is string =>
+            typeof nodeId === 'string' && nodeId.trim().length > 0,
+        ),
+      ),
     )
   }
 

--- a/src/test/storage/sanitizePersistedLensState.test.ts
+++ b/src/test/storage/sanitizePersistedLensState.test.ts
@@ -62,6 +62,14 @@ describe('sanitizePersistedLensState', () => {
     expect(result.expandedNodes).toEqual(['node1'])
   })
 
+  it('should deduplicate valid expandedNodes while preserving first-seen order', () => {
+    const result = sanitizePersistedLensState({
+      expandedNodes: ['node2', 'node1', 'node2', '', 'node1', 'node3'],
+    })
+
+    expect(result.expandedNodes).toEqual(['node2', 'node1', 'node3'])
+  })
+
   it('should strip unknown top-level fields', () => {
     const input = {
       networkConfig: defaultNetworkConfig,


### PR DESCRIPTION
Deduplicate valid expanded node IDs while preserving their persisted order.

Closes #388