### PR TITLE
fix: reject future-dated timestamps during watchlist hydration  (#427)

### DIFF
--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -219,6 +219,7 @@ export function sanitizeWatchlist(
     return {}
   }
 
+  const hydrationTime = Date.now()
   const source = value as Record<string, unknown>
   const sanitized: Record<string, Array<WatchlistItem>> = {}
 
@@ -226,22 +227,26 @@ export function sanitizeWatchlist(
     if (typeof contractId !== 'string' || contractId.length === 0) {
       continue
     }
+
     if (!Array.isArray(items)) {
       continue
     }
 
     const validItems: Array<WatchlistItem> = []
+
     for (const item of items) {
+      if (typeof item !== 'object' || item === null) {
+        continue
+      }
+
+      const candidate = item as Record<string, unknown>
+
       if (
-        typeof item === 'object' &&
-        item !== null &&
-        'contractId' in item &&
-        'keyPath' in item &&
-        'timestamp' in item &&
-        typeof (item as Record<string, unknown>).contractId === 'string' &&
-        typeof (item as Record<string, unknown>).keyPath === 'string' &&
-        typeof (item as Record<string, unknown>).timestamp === 'number' &&
-        Number.isFinite((item as Record<string, unknown>).timestamp as number)
+        typeof candidate.contractId === 'string' &&
+        typeof candidate.keyPath === 'string' &&
+        typeof candidate.timestamp === 'number' &&
+        Number.isFinite(candidate.timestamp) &&
+        candidate.timestamp <= hydrationTime
       ) {
         validItems.push(item as unknown as WatchlistItem)
       }

--- a/src/test/store/persistence.test.ts
+++ b/src/test/store/persistence.test.ts
@@ -9,6 +9,7 @@ import {
   serializeNetworkConfigForStorage,
 } from '../../store/persistence'
 import { DEFAULT_NETWORKS } from '../../store/types'
+import { useLensStore } from '@/store/lensStore'
 
 // Simple localStorage mock for node environment
 const localStorageMock = (function () {
@@ -273,6 +274,118 @@ describe('persistence', () => {
       })
       expect(result.C1).toHaveLength(1)
       expect(result.C1[0].keyPath).toBe('k')
+    })
+
+    it('drops future-dated items while preserving present and past items', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-27T12:00:00.000Z'))
+
+      try {
+        const now = Date.now()
+
+        const result = sanitizeWatchlist({
+          C1: [
+            {
+              contractId: 'C1',
+              keyPath: 'past',
+              timestamp: now - 1,
+            },
+            {
+              contractId: 'C1',
+              keyPath: 'present',
+              timestamp: now,
+            },
+            {
+              contractId: 'C1',
+              keyPath: 'future',
+              timestamp: now + 1,
+            },
+          ],
+        })
+
+        expect(result).toEqual({
+          C1: [
+            {
+              contractId: 'C1',
+              keyPath: 'past',
+              timestamp: now - 1,
+            },
+            {
+              contractId: 'C1',
+              keyPath: 'present',
+              timestamp: now,
+            },
+          ],
+        })
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('omits the contract entirely when every item is future-dated', () => {
+      const now = Date.now()
+      const result = sanitizeWatchlist({
+        C1: [{ contractId: 'C1', keyPath: 'a', timestamp: now + 1000 }],
+      })
+      expect(result).toEqual({})
+    })
+
+    it('handles valid, future-dated, and malformed items together', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-27T12:00:00.000Z'))
+
+      try {
+        const now = Date.now()
+
+        const result = sanitizeWatchlist({
+          C1: [
+            { contractId: 'C1', keyPath: 'valid', timestamp: now - 100 },
+            { contractId: 'C1', keyPath: 'future', timestamp: now + 100 },
+            {
+              contractId: 'C1',
+              keyPath: 'bad-type',
+              timestamp: 'not-a-number',
+            },
+            null,
+          ],
+        })
+
+        expect(result).toEqual({
+          C1: [
+            {
+              contractId: 'C1',
+              keyPath: 'valid',
+              timestamp: now - 100,
+            },
+          ],
+        })
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('preserves an item added immediately before hydration', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-27T12:00:00.000Z'))
+
+      try {
+        useLensStore.setState({ watchlist: {} })
+
+        useLensStore.getState().addToWatchlist('C1', '/some/key')
+
+        const result = sanitizeWatchlist(useLensStore.getState().watchlist)
+
+        expect(result.C1).toEqual([
+          {
+            contractId: 'C1',
+            keyPath: '/some/key',
+            timestamp: Date.now(),
+          },
+        ])
+      } finally {
+        useLensStore.setState({ watchlist: {} })
+        vi.useRealTimers()
+      }
     })
 
     it('omits contracts whose items all failed validation', () => {


### PR DESCRIPTION
## Summary

Rejects future-dated timestamps in `sanitizeWatchlist` during hydration, so a corrupted or tampered persisted timestamp can no longer display a watchlist item as pinned in the future.

Closes #427.

### Issue

`sanitizeWatchlist` (`src/store/persistence.ts`) already rejected non-finite timestamps but accepted any finite number, including ones later than the current clock.

### Fix

- Captures `hydrationTime = Date.now()` once per call, then adds `candidate.timestamp <= hydrationTime` to the existing per-item validation.
- Boundary is inclusive — items timestamped exactly at `hydrationTime` are kept.
- Malformed-entry isolation unchanged: bad items are filtered individually without affecting siblings; a contract with zero valid items is omitted, same as existing behavior.
- No write-path changes — `addToWatchlist` still stamps `Date.now()` at pin-time.

### Unchanged

- Timestamp source/format (`Date.now()`, epoch ms) on both write and read paths.
- No timestamp migration, no server clock sync — validation is local-clock-only, per issue scope.
- No new logging — `sanitizeWatchlist` doesn't really warn on dropped items, consistent with its behavior before I did changes.

## Test Plan

- [x] Vitest
  - `116/116 test files, 1375/1375 tests passing`
  - `drops future-dated items while preserving present and past items` — deterministic via fake timers, asserts the `<=` boundary at `now - 1` / `now` / `now + 1`
  - `omits the contract entirely when every item is future-dated`
  - `handles valid, future-dated, and malformed items together`
  - `preserves an item added immediately before hydration` — round-trips through the real `addToWatchlist` action to confirm write/hydration clocks agree