### PR TITLE
Distinguish truncated and cycle row previews in TreeRow

### DIFF
--- a/src/components/explorer/TreeRow.tsx
+++ b/src/components/explorer/TreeRow.tsx
@@ -24,9 +24,9 @@ function formatPreview(row: FlatTreeRow): string {
     case 'unsupported':
       return row.node.variant
     case 'truncated':
-      return `depth=${row.node.depth}`
+      return `truncated at depth=${row.node.depth}`
     case 'cycle':
-      return `depth=${row.node.depth}`
+      return `cycle detected at depth=${row.node.depth}`
     default:
       return ''
   }

--- a/src/test/components/TreeRow.test.tsx
+++ b/src/test/components/TreeRow.test.tsx
@@ -81,4 +81,44 @@ describe('TreeRow', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Open entry[0].value' }))
     expect(onActivate).toHaveBeenCalledWith(row)
   })
+
+  it('shows a distinct truncation preview for truncated marker rows', () => {
+    const row = makeRow({
+      kind: 'truncated',
+      label: 'truncated-marker',
+      node: { kind: 'truncated', path: [], depth: 3 },
+    })
+
+    render(
+      <TreeRow
+        row={row}
+        rowHeight={40}
+        isExpanded={false}
+        isSelected={false}
+      />,
+    )
+
+    expect(screen.getByText('truncated')).toBeTruthy()
+    expect(screen.getByText('truncated at depth=3')).toBeTruthy()
+  })
+
+  it('shows a distinct cycle preview for cycle marker rows', () => {
+    const row = makeRow({
+      kind: 'cycle',
+      label: 'cycle-marker',
+      node: { kind: 'cycle', path: [], depth: 3 },
+    })
+
+    render(
+      <TreeRow
+        row={row}
+        rowHeight={40}
+        isExpanded={false}
+        isSelected={false}
+      />,
+    )
+
+    expect(screen.getByText('cycle')).toBeTruthy()
+    expect(screen.getByText('cycle detected at depth=3')).toBeTruthy()
+  })
 })


### PR DESCRIPTION
## Summary

- give truncated marker rows a truncation-specific preview
- give cycle marker rows a cycle-specific preview
- add row-level coverage to prove the two marker kinds render different labels

## Why

Both marker kinds previously rendered the same `depth=...` preview, which made a truncation limit look identical to a cyclic reference. This change makes the two states visually distinct without changing the row layout.

## Validation

```text
npm test -- --run src/test/components/TreeRow.test.tsx src/test/tree/flatTreeRow.test.ts src/test/tree/flattenTree.test.ts
  Test Files  3 passed (3)
  Tests       17 passed (17)

npm run build
  vite build && tsc
  PASS
```

Closes #301

Supersedes closed draft #402 with the same validated commit, now submitted ready for review.
