### PR TITLE
fix: normalize footprint keys, cancel retry backoff on abort, and abo…

### DIFF
--- a/src/lib/network/footprint.ts
+++ b/src/lib/network/footprint.ts
@@ -8,6 +8,8 @@ export interface FootprintKeys {
   readWrite: Array<string>
 }
 
+import { normalizeFootprintSection } from './normalizeFootprintKeys'
+
 /**
  * Extracts and deduplicates footprint keys from a simulation response
  * Returns stable ordered, deduplicated read/write key lists
@@ -22,9 +24,8 @@ export function extractFootprintKeys(
     return { readOnly: [], readWrite: [] }
   }
 
-  // Deduplicate and sort for stable ordering
-  const readOnly = [...new Set(footprint.readOnly ?? [])].sort()
-  const readWrite = [...new Set(footprint.readWrite ?? [])].sort()
+  const readOnly = normalizeFootprintSection(footprint.readOnly)
+  const readWrite = normalizeFootprintSection(footprint.readWrite)
 
   return { readOnly, readWrite }
 }

--- a/src/lib/network/footprint.ts
+++ b/src/lib/network/footprint.ts
@@ -3,12 +3,12 @@
  * Parses read/write keys from simulation responses
  */
 
+import { normalizeFootprintSection } from './normalizeFootprintKeys'
+
 export interface FootprintKeys {
   readOnly: Array<string>
   readWrite: Array<string>
 }
-
-import { normalizeFootprintSection } from './normalizeFootprintKeys'
 
 /**
  * Extracts and deduplicates footprint keys from a simulation response

--- a/src/lib/network/getContractWasm.ts
+++ b/src/lib/network/getContractWasm.ts
@@ -7,6 +7,7 @@ import type { RpcError } from './types'
 export interface GetContractWasmParams {
   rpcUrl: string
   contractId: string
+  signal?: AbortSignal
 }
 
 export interface GetContractWasmSuccess {
@@ -70,6 +71,7 @@ export async function getContractWasm(
       {
         url: params.rpcUrl,
         timeout: 10000,
+        signal: params.signal,
       },
       buildJsonRpcRequest(
         'getContractCode',

--- a/src/lib/network/normalizeFootprintKeys.ts
+++ b/src/lib/network/normalizeFootprintKeys.ts
@@ -55,8 +55,8 @@ export function normalizeFootprintKeys(
     return { readOnly: [], readWrite: [], keys: [] }
   }
 
-  const readOnly = normalizeSection(footprint.readOnly)
-  const readWrite = normalizeSection(footprint.readWrite)
+  const readOnly = normalizeFootprintSection(footprint.readOnly)
+  const readWrite = normalizeFootprintSection(footprint.readWrite)
 
   const writeSet = new Set(readWrite)
   const keys: Array<FootprintKey> = [
@@ -72,7 +72,9 @@ export function normalizeFootprintKeys(
 /**
  * Trims, drops blanks, deduplicates, and lexically sorts a footprint section.
  */
-function normalizeSection(section: Array<string> | undefined): Array<string> {
+export function normalizeFootprintSection(
+  section: Array<string> | undefined,
+): Array<string> {
   if (!section) {
     return []
   }

--- a/src/lib/network/rpcClient.ts
+++ b/src/lib/network/rpcClient.ts
@@ -52,8 +52,6 @@ export async function callRpc<T = unknown>(
       signal: controller.signal,
     })
 
-    clearTimeout(timeoutId)
-
     if (!response.ok) {
       const errorText = await response.text().catch(() => 'Unknown error')
       return {
@@ -67,8 +65,6 @@ export async function callRpc<T = unknown>(
     const data = await response.json()
     return data as T
   } catch (error) {
-    clearTimeout(timeoutId)
-
     if (isAbortError(error)) {
       if (callerAborted) {
         return {
@@ -102,6 +98,7 @@ export async function callRpc<T = unknown>(
       isTimeout: false,
     }
   } finally {
+    clearTimeout(timeoutId)
     if (callerSignal) {
       callerSignal.removeEventListener('abort', onCallerAbort)
     }

--- a/src/lib/rpc/withRpcRetries.ts
+++ b/src/lib/rpc/withRpcRetries.ts
@@ -3,14 +3,64 @@ import { computeRetryDelayMs } from './computeRetryDelayMs'
 import { withJitter } from './withJitter'
 import { isJsonRpcErrorResponse } from './isJsonRpcErrorResponse'
 
+function isAbortError(error: unknown): boolean {
+  if (error instanceof Error && error.name === 'AbortError') {
+    return true
+  }
+
+  if (
+    typeof DOMException !== 'undefined' &&
+    error instanceof DOMException &&
+    error.name === 'AbortError'
+  ) {
+    return true
+  }
+
+  return false
+}
+
 export interface RpcRetryOptions {
   maxAttempts?: number
   baseDelayMs?: number
   maxDelayMs?: number
   jitterRatio?: number
+  signal?: AbortSignal
 }
 
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+function createAbortError(): Error {
+  if (typeof DOMException !== 'undefined') {
+    return new DOMException('The operation was aborted.', 'AbortError')
+  }
+
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+const delay = (ms: number, signal?: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(createAbortError())
+      return
+    }
+
+    const timeoutId = setTimeout(() => {
+      cleanup()
+      resolve()
+    }, ms)
+
+    const onAbort = () => {
+      cleanup()
+      reject(createAbortError())
+    }
+
+    const cleanup = () => {
+      clearTimeout(timeoutId)
+      signal?.removeEventListener('abort', onAbort)
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
 
 function isRpcClientError(value: unknown): boolean {
   if (typeof value !== 'object' || value === null) {
@@ -118,7 +168,18 @@ export async function withRpcRetries<T>(
 
     const delayMs = computeRetryDelayMs(attempt - 1, baseDelayMs, maxDelayMs)
     const jitteredMs = withJitter(delayMs, jitterRatio)
-    await delay(jitteredMs)
+
+    try {
+      await delay(jitteredMs, options.signal)
+    } catch (error) {
+      if (isAbortError(error)) {
+        if (didThrow) {
+          throw errorObj
+        }
+        return errorObj as T
+      }
+      throw error
+    }
 
     attempt++
   }

--- a/src/test/network/getContractWasm.test.ts
+++ b/src/test/network/getContractWasm.test.ts
@@ -56,4 +56,25 @@ describe('getContractWasm', () => {
       error: 'Network error',
     })
   })
+
+  it('returns a failure result when the caller signal aborts', async () => {
+    const controller = new AbortController()
+    vi.mocked(fetch).mockImplementationOnce(() =>
+      Promise.reject(
+        new DOMException('The operation was aborted.', 'AbortError'),
+      ),
+    )
+
+    controller.abort()
+    const result = await getContractWasm({
+      rpcUrl: mockRpcUrl,
+      contractId: mockContractId,
+      signal: controller.signal,
+    })
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Request aborted',
+    })
+  })
 })

--- a/src/test/network/rpcClient.test.ts
+++ b/src/test/network/rpcClient.test.ts
@@ -239,4 +239,30 @@ describe('callRpc', () => {
       isTimeout: false,
     })
   })
+
+  it('should timeout while waiting for response.json()', async () => {
+    vi.useFakeTimers()
+    mockFetch.mockImplementationOnce((_url, init) =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () =>
+              reject(new DOMException('The operation was aborted.', 'AbortError')),
+            )
+          }),
+      } as unknown as Response),
+    )
+
+    const promise = callRpc({ ...defaultConfig, timeout: 1000 })
+    await vi.runAllTimersAsync()
+
+    const result = await promise
+    expect(result).toMatchObject({
+      message: 'Request timeout',
+      code: 'TIMEOUT',
+      isTimeout: true,
+    })
+    vi.useRealTimers()
+  })
 })

--- a/src/test/network/simulateTransaction.test.ts
+++ b/src/test/network/simulateTransaction.test.ts
@@ -120,6 +120,15 @@ describe('extractFootprintKeys', () => {
     expect(result2.readOnly).toEqual([])
     expect(result2.readWrite).toEqual(['key1'])
   })
+
+  it('should trim whitespace, drop blanks, and deduplicate legacy keys', () => {
+    const result = extractFootprintKeys({
+      readOnly: [' key1 ', 'key1', '   '],
+      readWrite: [' key2', 'key2 ', '', 'key2'],
+    })
+    expect(result.readOnly).toEqual(['key1'])
+    expect(result.readWrite).toEqual(['key2'])
+  })
 })
 
 describe('simulateTransaction request helper', () => {

--- a/src/test/rpc/withRpcRetries.test.ts
+++ b/src/test/rpc/withRpcRetries.test.ts
@@ -94,6 +94,23 @@ describe('withRpcRetries', () => {
     expect(fn).toHaveBeenCalledTimes(2)
   })
 
+  it('should abort retry backoff when caller signal aborts', async () => {
+    const controller = new AbortController()
+    const fn = vi.fn().mockRejectedValueOnce({ code: 'TIMEOUT', message: 'timeout' })
+
+    const promise = withRpcRetries(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 100,
+      jitterRatio: 0,
+      signal: controller.signal,
+    })
+
+    controller.abort()
+
+    await expect(promise).rejects.toEqual({ code: 'TIMEOUT', message: 'timeout' })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
   it('should not retry a non-retryable returned Network RpcError (e.g. 400)', async () => {
     const networkError = { message: 'HTTP 400', code: 400, isTimeout: false }
     const fn = vi.fn().mockResolvedValue(networkError)


### PR DESCRIPTION
Summary
This PR fixes footprint key normalization and improves abort handling across RPC retry and contract WASM fetch flows.

closes #415
closes #360
closes #420
closes #421