### PR TITLE
Fix RPC request IDs, contract spec cache normalization, and ledger re…

### DIFF
--- a/src/lib/network/getLedgerEntries.ts
+++ b/src/lib/network/getLedgerEntries.ts
@@ -139,32 +139,35 @@ export async function getLedgerEntries(
       return { message: 'Invalid JSON-RPC response format', code: 'INVALID' }
     }
 
-    const opResult = data.result as {
-      entries?: Array<{
-        key?: unknown
-        xdr?: unknown
-        lastModifiedLedgerSeq?: number
-        liveUntilLedgerSeq?: number
-      }> | null
+    const rawResult = data.result
+    if (typeof rawResult !== 'object' || rawResult === null) {
+      return { message: 'Invalid JSON-RPC response format', code: 'INVALID' }
+    }
+
+    const opResult = rawResult as {
+      entries?: unknown
       latestLedger?: unknown
     }
 
     if (
-      !opResult ||
-      (opResult.entries !== null && !Array.isArray(opResult.entries)) ||
+      !('entries' in opResult) ||
+      !(opResult.entries === null || Array.isArray(opResult.entries)) ||
       typeof opResult.latestLedger !== 'number' ||
       !Number.isFinite(opResult.latestLedger)
     ) {
       return { message: 'Invalid JSON-RPC response format', code: 'INVALID' }
     }
 
-    if (opResult.entries !== null) {
-      const isValidEntries = opResult.entries.every((entry) => {
+    if (Array.isArray(opResult.entries)) {
+      const isValidEntries = opResult.entries.every((entry: unknown) => {
         if (!entry || typeof entry !== 'object') {
           return false
         }
 
-        return typeof (entry as { key?: unknown }).key === 'string' && typeof (entry as { xdr?: unknown }).xdr === 'string'
+        return (
+          typeof (entry as { key?: unknown }).key === 'string' &&
+          typeof (entry as { xdr?: unknown }).xdr === 'string'
+        )
       })
 
       if (!isValidEntries) {

--- a/src/lib/network/getLedgerEntries.ts
+++ b/src/lib/network/getLedgerEntries.ts
@@ -140,13 +140,36 @@ export async function getLedgerEntries(
     }
 
     const opResult = data.result as {
-      entries: Array<{
-        key: string
-        xdr: string
+      entries?: Array<{
+        key?: unknown
+        xdr?: unknown
         lastModifiedLedgerSeq?: number
         liveUntilLedgerSeq?: number
       }> | null
-      latestLedger: number
+      latestLedger?: unknown
+    }
+
+    if (
+      !opResult ||
+      (opResult.entries !== null && !Array.isArray(opResult.entries)) ||
+      typeof opResult.latestLedger !== 'number' ||
+      !Number.isFinite(opResult.latestLedger)
+    ) {
+      return { message: 'Invalid JSON-RPC response format', code: 'INVALID' }
+    }
+
+    if (opResult.entries !== null) {
+      const isValidEntries = opResult.entries.every((entry) => {
+        if (!entry || typeof entry !== 'object') {
+          return false
+        }
+
+        return typeof (entry as { key?: unknown }).key === 'string' && typeof (entry as { xdr?: unknown }).xdr === 'string'
+      })
+
+      if (!isValidEntries) {
+        return { message: 'Invalid JSON-RPC response format', code: 'INVALID' }
+      }
     }
 
     return {

--- a/src/lib/rpc/buildJsonRpcRequest.ts
+++ b/src/lib/rpc/buildJsonRpcRequest.ts
@@ -5,7 +5,7 @@
  * @param params - The parameters for the RPC call (can be an array, object, or other values).
  * @param id - A unique identifier for the request.
  * @returns A strictly typed JSON-RPC 2.0 request object.
- * @throws Error if the method name is empty.
+ * @throws Error if the method name is empty or the request ID is invalid.
  */
 export function buildJsonRpcRequest(
   method: string,
@@ -14,6 +14,10 @@ export function buildJsonRpcRequest(
 ): { jsonrpc: '2.0'; method: string; params: unknown; id: number } {
   if (!method || method.trim().length === 0) {
     throw new Error('JSON-RPC method name cannot be empty')
+  }
+
+  if (!Number.isSafeInteger(id) || id <= 0) {
+    throw new Error('JSON-RPC request ID must be a finite positive integer')
   }
 
   return {

--- a/src/lib/rpc/toRpcRequestId.ts
+++ b/src/lib/rpc/toRpcRequestId.ts
@@ -8,7 +8,13 @@ let lastId = 0
  */
 export function toRpcRequestId(seed?: number): number {
   if (seed === undefined) {
-    return ++lastId
+    if (lastId >= Number.MAX_SAFE_INTEGER) {
+      lastId = 0
+      return 1
+    }
+
+    lastId += 1
+    return lastId
   }
 
   // Handle non-finite or NaN seeds
@@ -18,7 +24,8 @@ export function toRpcRequestId(seed?: number): number {
 
   // Clamp invalid values and guarantee finite positive integer
   const absoluteValue = Math.abs(Math.trunc(seed))
+  const safeValue = Math.min(absoluteValue, Number.MAX_SAFE_INTEGER)
 
   // Guarantee positive (non-zero) integer
-  return absoluteValue || 1
+  return safeValue || 1
 }

--- a/src/store/contractSpecSlice.ts
+++ b/src/store/contractSpecSlice.ts
@@ -1,4 +1,10 @@
+import { normalizeContractIdInput } from '../lib/validation/normalizeContractIdInput'
 import type { ContractSpecSlice, LensStore } from './types'
+
+function normalizeContractSpecKey(contractId: string): string | null {
+  const normalized = normalizeContractIdInput(contractId)
+  return normalized.length > 0 ? normalized : null
+}
 
 export const createContractSpecSlice = (
   set: (fn: (state: LensStore) => Partial<LensStore>) => void,
@@ -6,16 +12,37 @@ export const createContractSpecSlice = (
 ): ContractSpecSlice => ({
   contractSpecs: {},
 
-  setContractSpec: (contractId: string, spec: unknown) =>
-    set((state) => ({
-      contractSpecs: { ...state.contractSpecs, [contractId]: spec },
-    })),
+  setContractSpec: (contractId: string, spec: unknown) => {
+    const normalizedContractId = normalizeContractSpecKey(contractId)
+    if (!normalizedContractId) {
+      return
+    }
 
-  getContractSpec: (contractId: string) => get().contractSpecs[contractId],
+    set((state) => ({
+      contractSpecs: {
+        ...state.contractSpecs,
+        [normalizedContractId]: spec,
+      },
+    }))
+  },
+
+  getContractSpec: (contractId: string) => {
+    const normalizedContractId = normalizeContractSpecKey(contractId)
+    if (!normalizedContractId) {
+      return undefined
+    }
+
+    return get().contractSpecs[normalizedContractId]
+  },
 
   clearContractSpec: (contractId: string) =>
     set((state) => {
-      const { [contractId]: _, ...rest } = state.contractSpecs
+      const normalizedContractId = normalizeContractSpecKey(contractId)
+      if (!normalizedContractId) {
+        return state
+      }
+
+      const { [normalizedContractId]: _, ...rest } = state.contractSpecs
       return { contractSpecs: rest }
     }),
 })

--- a/src/test/network/getLedgerEntries.test.ts
+++ b/src/test/network/getLedgerEntries.test.ts
@@ -182,6 +182,48 @@ describe('getLedgerEntries', () => {
         }),
       ).rejects.toThrow('Invalid JSON-RPC response format')
     })
+
+    it('throws error when ledger result entries are malformed', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            entries: [{ key: 'key1' }],
+            latestLedger: 100,
+          },
+        }),
+      } as Response)
+
+      await expect(
+        getLedgerEntries({
+          rpcUrl: mockRpcUrl,
+          keys: mockKeys,
+        }),
+      ).rejects.toThrow('Invalid JSON-RPC response format')
+    })
+
+    it('throws error when latestLedger is not a finite number', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            entries: [{ key: 'key1', xdr: 'xdr1' }],
+            latestLedger: '100',
+          },
+        }),
+      } as Response)
+
+      await expect(
+        getLedgerEntries({
+          rpcUrl: mockRpcUrl,
+          keys: mockKeys,
+        }),
+      ).rejects.toThrow('Invalid JSON-RPC response format')
+    })
   })
 
   describe('abort scenarios', () => {

--- a/src/test/rpc/buildJsonRpcRequest.test.ts
+++ b/src/test/rpc/buildJsonRpcRequest.test.ts
@@ -55,7 +55,7 @@ describe('buildJsonRpcRequest', () => {
     'should reject invalid request ids: %p',
     (invalidId) => {
       expect(() =>
-        buildJsonRpcRequest('someMethod', {}, invalidId as number),
+        buildJsonRpcRequest('someMethod', {}, invalidId),
       ).toThrow('JSON-RPC request ID must be a finite positive integer')
     },
   )

--- a/src/test/rpc/buildJsonRpcRequest.test.ts
+++ b/src/test/rpc/buildJsonRpcRequest.test.ts
@@ -50,4 +50,13 @@ describe('buildJsonRpcRequest', () => {
     const resultUndefined = buildJsonRpcRequest('someMethod', undefined, 1)
     expect(resultUndefined.params).toBeUndefined()
   })
+
+  it.each([0, -1, 1.5, NaN, Infinity, -Infinity])(
+    'should reject invalid request ids: %p',
+    (invalidId) => {
+      expect(() =>
+        buildJsonRpcRequest('someMethod', {}, invalidId as number),
+      ).toThrow('JSON-RPC request ID must be a finite positive integer')
+    },
+  )
 })

--- a/src/test/rpc/toRpcRequestId.test.ts
+++ b/src/test/rpc/toRpcRequestId.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { toRpcRequestId } from '../../lib/rpc/toRpcRequestId'
 
 describe('toRpcRequestId', () => {
@@ -41,6 +41,17 @@ describe('toRpcRequestId', () => {
   it('should handle large safe integers', () => {
     const largeSeed = Number.MAX_SAFE_INTEGER
     expect(toRpcRequestId(largeSeed)).toBe(largeSeed)
+  })
+
+  it('wraps the generated counter before it exceeds the safe integer range', async () => {
+    vi.resetModules()
+    const { toRpcRequestId } = await import('../../lib/rpc/toRpcRequestId')
+
+    const seededId = toRpcRequestId(Number.MAX_SAFE_INTEGER - 1)
+    const wrappedId = toRpcRequestId()
+
+    expect(seededId).toBe(Number.MAX_SAFE_INTEGER - 1)
+    expect(wrappedId).toBe(1)
   })
 
   it('should return 1 for negative zero', () => {

--- a/src/test/store/contractSpecSlice.test.ts
+++ b/src/test/store/contractSpecSlice.test.ts
@@ -45,6 +45,21 @@ describe('contractSpecSlice', () => {
     expect(getStoreState().getContractSpec('CONTRACT_B')).toEqual({ name: 'B' })
   })
 
+  it('normalizes equivalent contract IDs to the same cache entry', () => {
+    getStoreState().setContractSpec('  c123   ', { name: 'A' })
+
+    expect(getStoreState().getContractSpec('C123')).toEqual({ name: 'A' })
+  })
+
+  it('ignores blank contract IDs when storing specs', () => {
+    getStoreState().setContractSpec('   ', { name: 'A' })
+    getStoreState().setContractSpec('\n\t', { name: 'B' })
+
+    expect(getStoreState().contractSpecs).toEqual({})
+    expect(getStoreState().getContractSpec('   ')).toBeUndefined()
+    expect(getStoreState().getContractSpec('\n\t')).toBeUndefined()
+  })
+
   it('does not affect other store state when setting a spec', () => {
     const before = getStoreState()
     const ledgerDataBefore = before.ledgerData


### PR DESCRIPTION
# PR Summary

Implements focused RPC and store-slice hardening for request IDs, contract-spec caching, and ledger-entry validation.

## What changed

- Wrap generated RPC request IDs safely before they reach the JS safe-integer limit.
- Validate JSON-RPC request IDs before building payloads, rejecting invalid values early.
- Normalize contract IDs in the contract-spec cache so equivalent inputs resolve to the same entry.
- Validate ledger-entry result shape before mapping to prevent malformed RPC responses from crashing downstream flows.

## Verification

- `node node_modules/vitest/vitest.mjs run src/test/rpc/toRpcRequestId.test.ts src/test/rpc/buildJsonRpcRequest.test.ts src/test/store/contractSpecSlice.test.ts src/test/network/getLedgerEntries.test.ts --reporter=default`



Closes #423
Closes #424
Closes #425
Closes #363