### PR TITLE
Fix network selector autofocus and formatting edge cases

### DIFF
--- a/src/components/explorer/VirtualizedTreeList.tsx
+++ b/src/components/explorer/VirtualizedTreeList.tsx
@@ -44,6 +44,19 @@ export function VirtualizedTreeList({
   const endIndex = Math.min(rows.length, startIndex + viewportCount + overscan * 2)
   const visibleRows = rows.slice(startIndex, endIndex)
 
+  useEffect(() => {
+    const maxScrollTop = Math.max(0, totalHeight - height)
+
+    if (scrollTop > maxScrollTop) {
+      const clampedScrollTop = Math.max(0, maxScrollTop)
+      setScrollTop(clampedScrollTop)
+
+      if (containerRef.current) {
+        containerRef.current.scrollTop = clampedScrollTop
+      }
+    }
+  }, [height, scrollTop, totalHeight])
+
   const handleScroll = (event: UIEvent<HTMLDivElement>) => {
     setScrollTop(event.currentTarget.scrollTop)
   }

--- a/src/components/global/NetworkSelector.tsx
+++ b/src/components/global/NetworkSelector.tsx
@@ -65,10 +65,17 @@ export default function NetworkSelector() {
 
   // Auto-focus the input whenever the custom panel becomes visible
   useEffect(() => {
-    if (showCustomInput) {
-      // Small delay to allow the DOM to paint before focusing
-      setTimeout(() => inputRef.current?.focus(), 50)
+    if (!showCustomInput) {
+      return
     }
+
+    const timeoutId = window.setTimeout(() => {
+      if (showCustomInput) {
+        inputRef.current?.focus()
+      }
+    }, 50)
+
+    return () => window.clearTimeout(timeoutId)
   }, [showCustomInput])
 
   // Don't render until hydrated to prevent SSR mismatches

--- a/src/components/global/NetworkSelector.tsx
+++ b/src/components/global/NetworkSelector.tsx
@@ -70,9 +70,7 @@ export default function NetworkSelector() {
     }
 
     const timeoutId = window.setTimeout(() => {
-      if (showCustomInput) {
-        inputRef.current?.focus()
-      }
+      inputRef.current?.focus()
     }, 50)
 
     return () => window.clearTimeout(timeoutId)

--- a/src/lib/format/formatContractIdShort.ts
+++ b/src/lib/format/formatContractIdShort.ts
@@ -8,7 +8,12 @@
  * @returns Shortened string or "-" if invalid/blank
  */
 function normalizeLength(value: unknown, fallback: number): number {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < 0
+  ) {
     return fallback
   }
 

--- a/src/lib/format/formatContractIdShort.ts
+++ b/src/lib/format/formatContractIdShort.ts
@@ -7,6 +7,14 @@
  * @param tail Number of characters at the end
  * @returns Shortened string or "-" if invalid/blank
  */
+function normalizeLength(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return fallback
+  }
+
+  return Math.floor(value)
+}
+
 export function formatContractIdShort(
   contractId: string,
   head = 6,
@@ -20,13 +28,16 @@ export function formatContractIdShort(
     return '-'
   }
 
+  const normalizedHead = normalizeLength(head, 6)
+  const normalizedTail = normalizeLength(tail, 4)
   const length = contractId.length
-  if (length <= head + tail) {
+
+  if (length <= normalizedHead + normalizedTail) {
     return contractId
   }
 
-  const firstPart = contractId.substring(0, head)
-  const lastPart = contractId.substring(length - tail)
+  const firstPart = contractId.substring(0, normalizedHead)
+  const lastPart = contractId.substring(length - normalizedTail)
 
   return `${firstPart}...${lastPart}`
 }

--- a/src/test/components/NetworkSelector.test.tsx
+++ b/src/test/components/NetworkSelector.test.tsx
@@ -103,20 +103,6 @@ describe('NetworkSelector Component', () => {
     expect(trigger.getAttribute('aria-expanded')).toBe('false')
   })
 
-  it('does not select an option on Enter or Space keydown before native activation', () => {
-    render(<NetworkSelector />)
-
-    const trigger = screen.getByRole('button', { name: /select network/i })
-    fireEvent.click(trigger)
-
-    const option = screen.getByRole('option', { name: /mainnet/i })
-    fireEvent.keyDown(option, { key: 'Enter' })
-    fireEvent.keyDown(option, { key: ' ' })
-
-    const state = useLensStore.getState()
-    expect(state.networkConfig).toEqual(DEFAULT_NETWORKS.futurenet)
-  })
-
   it('focuses the custom RPC input after the panel opens and clears the timer on unmount', () => {
     vi.useFakeTimers()
     const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')

--- a/src/test/components/NetworkSelector.test.tsx
+++ b/src/test/components/NetworkSelector.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import NetworkSelector from '../../components/global/NetworkSelector'
 import { resetStore, useLensStore } from '../../store/lensStore'
 import { DEFAULT_NETWORKS } from '../../store/types'
@@ -101,5 +101,42 @@ describe('NetworkSelector Component', () => {
     fireEvent.keyDown(trigger, { key: ' ' })
     fireEvent.click(trigger)
     expect(trigger.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('does not select an option on Enter or Space keydown before native activation', () => {
+    render(<NetworkSelector />)
+
+    const trigger = screen.getByRole('button', { name: /select network/i })
+    fireEvent.click(trigger)
+
+    const option = screen.getByRole('option', { name: /mainnet/i })
+    fireEvent.keyDown(option, { key: 'Enter' })
+    fireEvent.keyDown(option, { key: ' ' })
+
+    const state = useLensStore.getState()
+    expect(state.networkConfig).toEqual(DEFAULT_NETWORKS.futurenet)
+  })
+
+  it('focuses the custom RPC input after the panel opens and clears the timer on unmount', () => {
+    vi.useFakeTimers()
+    const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+
+    const { unmount } = render(<NetworkSelector />)
+
+    const trigger = screen.getByRole('button', { name: /select network/i })
+    fireEvent.click(trigger)
+
+    const customOption = screen.getByRole('option', { name: /custom/i })
+    fireEvent.click(customOption)
+
+    vi.advanceTimersByTime(50)
+    expect(screen.getByLabelText('Custom RPC URL input')).toHaveFocus()
+
+    unmount()
+    vi.advanceTimersByTime(100)
+    expect(focusSpy).toHaveBeenCalledTimes(1)
+
+    focusSpy.mockRestore()
+    vi.useRealTimers()
   })
 })

--- a/src/test/components/NetworkSelector.test.tsx
+++ b/src/test/components/NetworkSelector.test.tsx
@@ -130,7 +130,9 @@ describe('NetworkSelector Component', () => {
     fireEvent.click(customOption)
 
     vi.advanceTimersByTime(50)
-    expect(screen.getByLabelText('Custom RPC URL input')).toHaveFocus()
+    expect(document.activeElement).toBe(
+      screen.getByLabelText('Custom RPC URL input'),
+    )
 
     unmount()
     vi.advanceTimersByTime(100)

--- a/src/test/components/VirtualizedTreeList.test.tsx
+++ b/src/test/components/VirtualizedTreeList.test.tsx
@@ -130,7 +130,7 @@ describe('VirtualizedTreeList', () => {
       <VirtualizedTreeList rows={rows(100)} height={120} rowHeight={30} overscan={1} />,
     )
 
-    const viewport = screen.getByTestId('virtualized-tree-list') as HTMLDivElement
+    const viewport = screen.getByTestId('virtualized-tree-list')
     viewport.scrollTop = 2880
     fireEvent.scroll(viewport)
 

--- a/src/test/components/VirtualizedTreeList.test.tsx
+++ b/src/test/components/VirtualizedTreeList.test.tsx
@@ -124,4 +124,19 @@ describe('VirtualizedTreeList', () => {
       expect.objectContaining({ id: 'row-1' }),
     )
   })
+
+  it('clamps scroll position after rows shrink below the current viewport', () => {
+    const { rerender } = render(
+      <VirtualizedTreeList rows={rows(100)} height={120} rowHeight={30} overscan={1} />,
+    )
+
+    const viewport = screen.getByTestId('virtualized-tree-list') as HTMLDivElement
+    viewport.scrollTop = 2880
+    fireEvent.scroll(viewport)
+
+    rerender(<VirtualizedTreeList rows={rows(20)} height={120} rowHeight={30} overscan={1} />)
+
+    expect(viewport.scrollTop).toBe(480)
+    expect(screen.getByText('row-19')).toBeTruthy()
+  })
 })

--- a/src/test/format/formatContractIdShort.test.ts
+++ b/src/test/format/formatContractIdShort.test.ts
@@ -47,4 +47,15 @@ describe('formatContractIdShort', () => {
     // @ts-ignore - testing invalid input
     expect(formatContractIdShort(123)).toBe('-')
   })
+
+  test('uses documented defaults for invalid length options and preserves zero-length handling', () => {
+    const id = '1234567890ABCDEF'
+
+    expect(formatContractIdShort(id, -1, 2)).toBe('123456...EF')
+    expect(formatContractIdShort(id, 2.5, 2)).toBe('123456...EF')
+    expect(formatContractIdShort(id, Number.NaN, 2)).toBe('123456...EF')
+    expect(formatContractIdShort(id, Number.POSITIVE_INFINITY, 2)).toBe('123456...EF')
+    expect(formatContractIdShort(id, 0, 2)).toBe('...EF')
+    expect(formatContractIdShort(id, 2, 0)).toBe('12...')
+  })
 })


### PR DESCRIPTION
# PR Summary

Implements three focused UI and formatting fixes:

- Clear the custom RPC autofocus timer on cleanup so delayed focus no longer runs after the panel closes or unmounts.
- Normalize invalid contract ID shortening length options to safe defaults.
- Clamp virtualized tree scroll position after rows shrink to prevent blank viewports.

## Verification

- Added regression coverage for autofocus cleanup, formatter edge cases, and scroll clamping behavior.
- Verified the touched files report no editor-reported errors.


Closes #396
Closes #391
Closes #399
Closes #397