### PR TITLE
Distinguish cycle markers from depth truncation (#371)

### DIFF
--- a/src/test/decoder/cycle-guard.test.ts
+++ b/src/test/decoder/cycle-guard.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
+  
   ScValType,
   VisitedTracker,
   createVisitedTracker,
-  normalizeScVal,
+  normalizeScVal
 } from '../../workers/decoder/normalizeScVal'
-import type { ScVal } from '../../workers/decoder/normalizeScVal'
+import type {ScVal} from '../../workers/decoder/normalizeScVal';
 // (NormalizedValue type import removed — unused in tests)
 
 describe('Cycle Guard - Visited Node Tracking', () => {
@@ -53,7 +54,7 @@ describe('Cycle Guard - Visited Node Tracking', () => {
 
     it('should create cycle markers', () => {
       const marker = VisitedTracker.createCycleMarker()
-      expect((marker as any).kind).toBe('truncated')
+      expect((marker as any).kind).toBe('cycle')
       expect(VisitedTracker.isCycleMarker(marker)).toBe(true)
     })
 
@@ -63,15 +64,17 @@ describe('Cycle Guard - Visited Node Tracking', () => {
     })
 
     it('should correctly identify cycle markers', () => {
-      const validMarker = { kind: 'truncated' }
+      const validMarker = { kind: 'cycle' }
       const invalidMarker1 = { kind: 'primitive' }
-      const invalidMarker2 = { other: true }
-      const invalidMarker3 = null
+      const invalidMarker2 = { kind: 'truncated' }
+      const invalidMarker3 = { other: true }
+      const invalidMarker4 = null
 
       expect(VisitedTracker.isCycleMarker(validMarker)).toBe(true)
       expect(VisitedTracker.isCycleMarker(invalidMarker1)).toBe(false)
       expect(VisitedTracker.isCycleMarker(invalidMarker2)).toBe(false)
       expect(VisitedTracker.isCycleMarker(invalidMarker3)).toBe(false)
+      expect(VisitedTracker.isCycleMarker(invalidMarker4)).toBe(false)
     })
 
     it('should maintain depth count', () => {
@@ -312,7 +315,7 @@ describe('Cycle Guard - Visited Node Tracking', () => {
       const json = JSON.stringify(marker)
       const parsed = JSON.parse(json)
 
-      expect(parsed.kind).toBe('truncated')
+      expect(parsed.kind).toBe('cycle')
       expect(parsed.depth).toBe(3)
     })
   })

--- a/src/types/normalized.ts
+++ b/src/types/normalized.ts
@@ -155,6 +155,13 @@ export interface NormalizedAddress {
   value: string
 }
 
+// Cycle marker for detecting repeated object references
+export interface NormalizedCycle {
+  kind: 'cycle'
+  depth?: number
+}
+
+// Truncated marker for max-depth cutoff
 export interface NormalizedTruncated {
   kind: 'truncated'
   depth?: number
@@ -171,6 +178,7 @@ export type NormalizedValue =
   | NormalizedVec
   | NormalizedMap
   | NormalizedAddress
+  | NormalizedCycle
   | NormalizedTruncated
   | NormalizedError
   | NormalizedUnsupported

--- a/src/workers/decoder/guards.ts
+++ b/src/workers/decoder/guards.ts
@@ -3,7 +3,7 @@
  * Prevents infinite recursion from cyclic object references
  */
 
-import type { NormalizedTruncated } from '../../types/normalized'
+import type { NormalizedCycle } from '../../types/normalized'
 
 /**
  * Visited node tracker for cycle detection
@@ -60,9 +60,9 @@ export class VisitedTracker {
   /**
    * Create a cycle marker to return when a cycle is detected
    */
-  static createCycleMarker(depth?: number): NormalizedTruncated {
+  static createCycleMarker(depth?: number): NormalizedCycle {
     return {
-      kind: 'truncated',
+      kind: 'cycle',
       depth,
     }
   }
@@ -70,12 +70,12 @@ export class VisitedTracker {
   /**
    * Check if a value is a cycle marker
    */
-  static isCycleMarker(value: unknown): value is NormalizedTruncated {
+  static isCycleMarker(value: unknown): value is NormalizedCycle {
     return (
       typeof value === 'object' &&
       value !== null &&
       'kind' in value &&
-      (value as Record<string, unknown>).kind === 'truncated'
+      (value as Record<string, unknown>).kind === 'cycle'
     )
   }
 

--- a/src/workers/decoder/normalizeScVal.ts
+++ b/src/workers/decoder/normalizeScVal.ts
@@ -6,8 +6,8 @@ import {
 } from '../../lib/format/bytesToHex'
 import { VisitedTracker, createVisitedTracker } from './guards'
 import type {
-  CycleMarker,
   NormalizedAddress,
+  NormalizedCycle,
   NormalizedError,
   NormalizedMap,
   NormalizedMapEntry,
@@ -23,6 +23,7 @@ export { VisitedTracker, createVisitedTracker }
 
 // Re-export normalized types so consumers can import from a single location
 export type {
+  NormalizedCycle,
   NormalizedError,
   NormalizedMapEntry,
   NormalizedTruncated,
@@ -81,7 +82,7 @@ export type NormalizedValue =
   | number
   | string
   | null
-  | CycleMarker
+  | NormalizedCycle
   | NormalizedTruncated
   | NormalizedError
   | NormalizedUnsupported
@@ -265,7 +266,14 @@ function parts256ToString(value: unknown, signed: boolean): string | null {
     if (hiHi < minI64 || hiHi > maxI64) {
       return null
     }
-    if (hiLo < 0n || hiLo > maxU64 || loHi < 0n || loHi > maxU64 || loLo < 0n || loLo > maxU64) {
+    if (
+      hiLo < 0n ||
+      hiLo > maxU64 ||
+      loHi < 0n ||
+      loHi > maxU64 ||
+      loLo < 0n ||
+      loLo > maxU64
+    ) {
       return null
     }
 


### PR DESCRIPTION
Cycle detection now emits a distinct 'cycle' marker kind instead of reusing the 'truncated' marker kind. This allows consumers to distinguish between repeated object references (cycles) and max-depth cutoffs.

Changes:
- Add NormalizedCycle interface with kind: 'cycle' in normalized.ts
- Update VisitedTracker.createCycleMarker() to return NormalizedCycle
- Update VisitedTracker.isCycleMarker() to check for kind: 'cycle'
- Update cycle-guard.test.ts to expect kind: 'cycle' for cycle markers
- Keep depth-limit markers unchanged (kind: 'truncated')

Both marker shapes remain JSON-serializable and have distinct kind values.


Closes #371