### PR TITLE
fix: continue ledger polling after RPC errors

### DIFF
--- a/src/lib/network/ledgerPoller.ts
+++ b/src/lib/network/ledgerPoller.ts
@@ -40,10 +40,16 @@ export function startLedgerHeadPoll(
     if (document.visibilityState === 'hidden') return
 
     const body = buildJsonRpcRequest('getLatestLedger', {}, toRpcRequestId())
-    const response = await callRpc<{ result?: LatestLedgerResult }>(
-      rpcConfig,
-      body,
-    )
+    let response: { result?: LatestLedgerResult } | RpcError
+    try {
+      response = await callRpc<{ result?: LatestLedgerResult }>(
+        rpcConfig,
+        body,
+      )
+    } catch {
+      // A transient RPC failure must not terminate the polling loop.
+      return
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- stop() can run during await
     if (stoppedRef.current) return

--- a/src/test/network/ledgerPoller.test.ts
+++ b/src/test/network/ledgerPoller.test.ts
@@ -160,6 +160,30 @@ describe('startLedgerHeadPoll', () => {
       stop()
       randomSpy.mockRestore()
     })
+
+    it('continues polling after an RPC request rejects', async () => {
+      const onLedgerChange = vi.fn()
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      mockCallRpc
+        .mockRejectedValueOnce(new Error('RPC unavailable'))
+        .mockResolvedValueOnce({ result: { sequence: 100 } })
+
+      const stop = startLedgerHeadPoll({
+        rpcConfig: defaultRpcConfig,
+        intervalMs: 1000,
+        onLedgerChange,
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(onLedgerChange).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(onLedgerChange).toHaveBeenCalledTimes(1)
+      expect(onLedgerChange).toHaveBeenCalledWith(100)
+
+      stop()
+      randomSpy.mockRestore()
+    })
   })
 
   describe('stop function', () => {


### PR DESCRIPTION
## Summary

Continue ledger head polling after transient RPC request failures.

## Changes

- Catch rejected ledger RPC requests without producing unhandled rejections.
- Keep scheduling the next poll after a failed request.
- Add failure-then-success fake-timer coverage.

## Verification

- `npm test -- src/test/network/ledgerPoller.test.ts`
- `npm run build`

Closes #417