### PR TITLE
fix: expose tree row expansion state

### DIFF
--- a/src/components/explorer/TreeRow.tsx
+++ b/src/components/explorer/TreeRow.tsx
@@ -94,6 +94,7 @@ export function TreeRow({
       }`}
       style={{ height: rowHeight }}
       aria-label={`Open ${row.label}`}
+      aria-expanded={row.hasChildren ? isExpanded : undefined}
     >
       <div style={{ marginLeft: row.depth * 16 }} className="flex items-center gap-2 min-w-0">
         {row.hasChildren ? (

--- a/src/test/components/TreeRow.test.tsx
+++ b/src/test/components/TreeRow.test.tsx
@@ -64,6 +64,52 @@ describe('TreeRow', () => {
     expect(screen.getByText('0 items')).toBeTruthy()
   })
 
+  it('reports expansion state only for expandable rows', () => {
+    const row = makeRow({
+      hasChildren: true,
+      kind: 'vec',
+      node: { kind: 'vec', path: [], items: [], raw: { switch: 'ScvVec' } },
+    })
+
+    const { rerender } = render(
+      <TreeRow
+        row={row}
+        rowHeight={40}
+        isExpanded={false}
+        isSelected={false}
+      />,
+    )
+
+    const expandableRow = screen.getByRole('button', {
+      name: 'Open entry[0].value',
+    })
+    expect(expandableRow.getAttribute('aria-expanded')).toBe('false')
+
+    rerender(
+      <TreeRow
+        row={row}
+        rowHeight={40}
+        isExpanded={true}
+        isSelected={false}
+      />,
+    )
+    expect(expandableRow.getAttribute('aria-expanded')).toBe('true')
+
+    rerender(
+      <TreeRow
+        row={makeRow()}
+        rowHeight={40}
+        isExpanded={false}
+        isSelected={false}
+      />,
+    )
+    expect(
+      screen
+        .getByRole('button', { name: 'Open entry[0].value' })
+        .getAttribute('aria-expanded'),
+    ).toBeNull()
+  })
+
   it('calls activate handler on row click', () => {
     const onActivate = vi.fn()
     const row = makeRow()


### PR DESCRIPTION
## Summary

Expose the expansion state of expandable tree rows to assistive technology.

## Changes

- Add `aria-expanded` to expandable tree rows.
- Omit expansion state from leaf rows.
- Add coverage for expanded, collapsed, and leaf states.

## Verification

- `npm test -- src/test/components/TreeRow.test.tsx`
- `npm run build`

Closes #398