### PR TITLE
fix: name landing contract search

### DIFF
--- a/src/components/Home/SearchLandingScreen.tsx
+++ b/src/components/Home/SearchLandingScreen.tsx
@@ -103,6 +103,7 @@ const SearchLandingScreen = () => {
                     }}
                     className="w-full bg-transparent border-none text-white placeholder-gray-600 focus:ring-0 focus:outline-none font-mono text-sm h-full placeholder:font-mono"
                     placeholder="Search Contract ID (C...) or Ledger Key"
+                    aria-label="Contract ID or ledger key"
                     type="text"
                   />
                   <div className="pr-2 flex items-center">

--- a/src/test/components/SearchLandingScreen.test.tsx
+++ b/src/test/components/SearchLandingScreen.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import SearchLandingScreen from '../../components/Home/SearchLandingScreen'
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+describe('SearchLandingScreen', () => {
+  it('exposes an accessible name for the contract search input', () => {
+    render(<SearchLandingScreen />)
+
+    expect(
+      screen.getByRole('textbox', { name: 'Contract ID or ledger key' }),
+    ).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

Give the landing contract search input a stable accessible name.

## Changes

- Add a screen-reader accessible name while preserving the existing placeholder and layout.
- Add a focused accessible-name assertion.

## Verification

- `npm test -- src/test/components/SearchLandingScreen.test.tsx`
- `npm run build`

Closes #392