### PR TITLE
feat(header): show compact brand mark on small viewports

### DIFF
--- a/src/components/global/Header.tsx
+++ b/src/components/global/Header.tsx
@@ -21,6 +21,11 @@ export default function Header({ handleToggle }: HeaderProp) {
               view_in_ar
             </span>
           </button>
+          {/* Compact logo: visible below xl */}
+          <h1 className="font-mono font-bold text-white tracking-tight flex xl:hidden">
+            SSL
+          </h1>
+          {/* Full title: visible on xl and above */}
           <h1 className="font-mono font-bold text-white hidden xl:text-lg tracking-tight xl:flex">
             SOROBAN STATE LENS
           </h1>


### PR DESCRIPTION
## Overview

This PR adds a compact **"SSL"** brand abbreviation visible below the xl breakpoint so the header always displays a brand identity on small viewports. The full **"SOROBAN STATE LENS"** title continues to show on xl screens and above.

## Related Issue

Closes #312

## Changes

### Responsive Brand Mark

* **[ADD]** Compact `SSL` h1 in the header's left section, visible below the xl breakpoint (`flex xl:hidden`).
* **[MODIFY]** The existing full-title h1 remains unchanged — still `hidden xl:flex` so it only renders on xl+.

## Verification Results

```
TypeScript: zero errors
Tests: 124/124 test files, 1461/1461 tests passed
Build: production build succeeds
```

| Acceptance Criteria | Status |
| --- | --- |
| Small viewports show a compact brand mark | OK "SSL" appears below 1280px |
| xl viewports keep the full title | OK "SOROBAN STATE LENS" appears at 1280px+ |
