### PR TITLE
Add deterministic grouped BigInt formatter

### DIFF
--- a/src/lib/format/formatBigInt.ts
+++ b/src/lib/format/formatBigInt.ts
@@ -1,0 +1,29 @@
+const INVALID_BIG_INT_FALLBACK = '-'
+
+/**
+ * Formats an integer with deterministic three-digit grouping.
+ *
+ * `Intl` is intentionally avoided so explorer output does not change with the
+ * host locale. Number inputs must be safe integers because lost precision
+ * cannot be recovered during formatting.
+ */
+export function formatBigInt(value: string | number | bigint): string {
+  if (typeof value === 'string' && value.trim() === '') {
+    return INVALID_BIG_INT_FALLBACK
+  }
+
+  if (typeof value === 'number' && !Number.isSafeInteger(value)) {
+    return INVALID_BIG_INT_FALLBACK
+  }
+
+  try {
+    const normalized = BigInt(value).toString()
+    const isNegative = normalized.startsWith('-')
+    const digits = isNegative ? normalized.slice(1) : normalized
+    const grouped = digits.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+
+    return isNegative ? `-${grouped}` : grouped
+  } catch {
+    return INVALID_BIG_INT_FALLBACK
+  }
+}

--- a/src/test/format/formatBigInt.test.ts
+++ b/src/test/format/formatBigInt.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { formatBigInt } from '../../lib/format/formatBigInt'
+
+describe('formatBigInt', () => {
+  it('groups the maximum u64 value without locale dependency', () => {
+    expect(formatBigInt('18446744073709551615')).toBe(
+      '18,446,744,073,709,551,615',
+    )
+  })
+
+  it('groups a negative i128 value while preserving its sign', () => {
+    expect(formatBigInt('-170141183460469231731687303715884105728')).toBe(
+      '-170,141,183,460,469,231,731,687,303,715,884,105,728',
+    )
+  })
+
+  it('accepts safe number and bigint inputs', () => {
+    expect(formatBigInt(1234567)).toBe('1,234,567')
+    expect(formatBigInt(0n)).toBe('0')
+  })
+
+  it('returns a stable fallback for invalid or imprecise input', () => {
+    expect(formatBigInt('not-an-integer')).toBe('-')
+    expect(formatBigInt('')).toBe('-')
+    expect(formatBigInt(1.5)).toBe('-')
+    expect(formatBigInt(Number.MAX_SAFE_INTEGER + 1)).toBe('-')
+  })
+})


### PR DESCRIPTION
## Summary

- add a locale-independent `formatBigInt` helper for string, number, and bigint inputs
- preserve negative signs and zero while grouping decimal digits
- return `-` for malformed, fractional, or unsafe-number input
- cover u64 max, negative i128, supported input types, and invalid boundaries

## Validation

- focused Vitest suite passed
- TypeScript check passed
- ESLint passed with zero warnings
- Prettier check passed

Ready-for-review replacement for closed draft #464.

Closes #302