### PR TITLE
Show bounded map-key previews in tree labels

### DIFF
--- a/src/lib/tree/flattenTree.ts
+++ b/src/lib/tree/flattenTree.ts
@@ -1,8 +1,39 @@
 import type { Node } from '../../types/node'
 import type { FlatTreeRow, FlattenTreeRoot } from './flatTreeRow'
 
+const MAP_KEY_PREVIEW_MAX_LENGTH = 24
+
 function isExpandable(node: Node): boolean {
   return node.kind === 'vec' || node.kind === 'map'
+}
+
+function getMapKeyPreview(node: Node): string | null {
+  let value: string | null = null
+
+  if (node.kind === 'primitive' && node.value !== null) {
+    value = String(node.value)
+  } else if (node.kind === 'address') {
+    value = node.value
+  } else if (node.kind === 'error') {
+    value = `${node.errorType}:${node.code}`
+  }
+
+  const normalized = value?.trim().replace(/\s+/g, ' ')
+  if (!normalized) {
+    return null
+  }
+
+  if (normalized.length <= MAP_KEY_PREVIEW_MAX_LENGTH) {
+    return normalized
+  }
+
+  return `${normalized.slice(0, MAP_KEY_PREVIEW_MAX_LENGTH - 1)}…`
+}
+
+function getMapKeyLabel(node: Node, index: number): string {
+  const baseLabel = `entry[${index}].key`
+  const preview = getMapKeyPreview(node)
+  return preview === null ? baseLabel : `${baseLabel} (${preview})`
 }
 
 function getChildren(node: Node): Array<{ idPart: string; label: string; node: Node }> {
@@ -19,7 +50,7 @@ function getChildren(node: Node): Array<{ idPart: string; label: string; node: N
       return [
         {
           idPart: `entry-${index}-key`,
-          label: `entry[${index}].key`,
+          label: getMapKeyLabel(entry.key, index),
           node: entry.key,
         },
         {

--- a/src/test/tree/flattenTree.test.ts
+++ b/src/test/tree/flattenTree.test.ts
@@ -15,6 +15,16 @@ function primitive(value: string): Node {
   }
 }
 
+function symbol(value: string): Node {
+  return {
+    kind: 'primitive',
+    path: [],
+    scType: 'symbol',
+    value,
+    raw: { switch: 'ScvSymbol' },
+  }
+}
+
 describe('flattenTree', () => {
   const tree: Node = {
     kind: 'map',
@@ -52,6 +62,57 @@ describe('flattenTree', () => {
       'root.entry-1-key',
       'root.entry-1-value',
     ])
+  })
+
+  it('includes short symbol previews in map key labels only', () => {
+    const symbolMap: Node = {
+      kind: 'map',
+      path: [],
+      raw: { switch: 'ScvMap' },
+      entries: [
+        { key: symbol('admin'), value: primitive('first') },
+        { key: symbol('treasury'), value: primitive('second') },
+      ],
+    }
+
+    const rows = flattenTree(
+      [{ id: 'root', label: 'root', node: symbolMap }],
+      ['root'],
+    )
+
+    expect(rows.map((row) => row.label)).toEqual([
+      'root',
+      'entry[0].key (admin)',
+      'entry[0].value',
+      'entry[1].key (treasury)',
+      'entry[1].value',
+    ])
+  })
+
+  it('falls back for unreadable keys and bounds long previews', () => {
+    const previewMap: Node = {
+      kind: 'map',
+      path: [],
+      raw: { switch: 'ScvMap' },
+      entries: [
+        {
+          key: { kind: 'truncated', path: [], depth: 1 },
+          value: primitive('first'),
+        },
+        {
+          key: symbol('a-very-long-symbol-key-that-must-be-shortened'),
+          value: primitive('second'),
+        },
+      ],
+    }
+
+    const rows = flattenTree(
+      [{ id: 'root', label: 'root', node: previewMap }],
+      ['root'],
+    )
+
+    expect(rows[1]?.label).toBe('entry[0].key')
+    expect(rows[3]?.label).toBe('entry[1].key (a-very-long-symbol-key-…)')
   })
 
   it('shows nested descendants deterministically', () => {


### PR DESCRIPTION
## Summary

- derive concise labels from readable normalized map-key nodes
- show symbol, primitive, address, and error previews without changing stable row IDs
- normalize whitespace and cap previews at 24 characters
- preserve the existing index-only fallback for unreadable keys
- keep all value-row labels unchanged

## Validation

- focused `flattenTree` suite passed: 10 tests
- TypeScript check passed
- ESLint passed with zero warnings
- diff check passed

Ready-for-review replacement for closed draft #465.

Closes #300